### PR TITLE
Improve LocalIndexStatsTest

### DIFF
--- a/hazelcast-client/src/test/java/com/hazelcast/client/map/ClientIndexStatsTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/map/ClientIndexStatsTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.hazelcast.client.map;
 
 import com.hazelcast.client.config.ClientConfig;

--- a/hazelcast-client/src/test/java/com/hazelcast/client/map/ClientIndexStatsTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/map/ClientIndexStatsTest.java
@@ -1,0 +1,150 @@
+package com.hazelcast.client.map;
+
+import com.hazelcast.client.config.ClientConfig;
+import com.hazelcast.client.test.TestHazelcastFactory;
+import com.hazelcast.config.Config;
+import com.hazelcast.config.InMemoryFormat;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.core.IMap;
+import com.hazelcast.map.LocalIndexStatsTest;
+import com.hazelcast.monitor.LocalIndexStats;
+import com.hazelcast.monitor.LocalMapStats;
+import com.hazelcast.monitor.impl.LocalIndexStatsImpl;
+import com.hazelcast.monitor.impl.LocalMapStatsImpl;
+import com.hazelcast.query.PartitionPredicate;
+import com.hazelcast.query.Predicates;
+import com.hazelcast.test.HazelcastParallelParametersRunnerFactory;
+import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.After;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+
+import static java.util.Arrays.asList;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+@RunWith(Parameterized.class)
+@Parameterized.UseParametersRunnerFactory(HazelcastParallelParametersRunnerFactory.class)
+@Category({QuickTest.class, ParallelTest.class})
+public class ClientIndexStatsTest extends LocalIndexStatsTest {
+
+    @Parameterized.Parameters(name = "format:{0}")
+    public static Collection<Object[]> parameters() {
+        return asList(new Object[][]{{InMemoryFormat.OBJECT}, {InMemoryFormat.BINARY}});
+    }
+
+    private TestHazelcastFactory hazelcastFactory = new TestHazelcastFactory();
+
+    private IMap map1;
+    private IMap map2;
+
+    private IMap noStatsMap1;
+    private IMap noStatsMap2;
+
+    @Override
+    protected HazelcastInstance createInstance(Config config) {
+        HazelcastInstance member1 = hazelcastFactory.newHazelcastInstance(config);
+        HazelcastInstance member2 = hazelcastFactory.newHazelcastInstance(config);
+
+        map1 = member1.getMap(mapName);
+        map2 = member2.getMap(mapName);
+
+        noStatsMap1 = member1.getMap(noStatsMapName);
+        noStatsMap2 = member2.getMap(noStatsMapName);
+
+        return hazelcastFactory.newHazelcastClient(new ClientConfig());
+    }
+
+    @After
+    public void after() {
+        hazelcastFactory.terminateAll();
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    @Override
+    public void testQueryCounting_WhenPartitionPredicateIsUsed() {
+        map.addIndex("this", false);
+
+        for (int i = 0; i < 100; ++i) {
+            map.put(i, i);
+        }
+
+        map.entrySet(new PartitionPredicate(10, Predicates.equal("this", 10)));
+        assertTrue(map1.getLocalMapStats().getQueryCount() == 1 && map2.getLocalMapStats().getQueryCount() == 0
+                || map1.getLocalMapStats().getQueryCount() == 0 && map2.getLocalMapStats().getQueryCount() == 1);
+        assertEquals(0, map1.getLocalMapStats().getIndexedQueryCount());
+        assertEquals(0, map2.getLocalMapStats().getIndexedQueryCount());
+        assertEquals(0, map1.getLocalMapStats().getIndexStats().get("this").getQueryCount());
+        assertEquals(0, map2.getLocalMapStats().getIndexStats().get("this").getQueryCount());
+    }
+
+    @Override
+    protected LocalMapStats stats() {
+        LocalMapStats stats1 = map1.getLocalMapStats();
+        LocalMapStats stats2 = map2.getLocalMapStats();
+        return combineStats(stats1, stats2);
+    }
+
+    @Override
+    protected LocalMapStats noStats() {
+        LocalMapStats stats1 = noStatsMap1.getLocalMapStats();
+        LocalMapStats stats2 = noStatsMap2.getLocalMapStats();
+        return combineStats(stats1, stats2);
+    }
+
+    private static LocalMapStats combineStats(LocalMapStats stats1, LocalMapStats stats2) {
+        LocalMapStatsImpl combinedStats = new LocalMapStatsImpl();
+
+        assertEquals(stats1.getQueryCount(), stats2.getQueryCount());
+        combinedStats.setQueryCount(stats1.getQueryCount());
+        assertEquals(stats1.getIndexedQueryCount(), stats2.getIndexedQueryCount());
+        combinedStats.setIndexedQueryCount(stats1.getIndexedQueryCount());
+
+        assertEquals(stats1.getIndexStats().size(), stats2.getIndexStats().size());
+        Map<String, LocalIndexStatsImpl> combinedIndexStatsMap = new HashMap<String, LocalIndexStatsImpl>();
+        for (Map.Entry<String, LocalIndexStats> indexEntry : stats1.getIndexStats().entrySet()) {
+            LocalIndexStats indexStats1 = indexEntry.getValue();
+            LocalIndexStats indexStats2 = stats2.getIndexStats().get(indexEntry.getKey());
+            assertNotNull(indexStats2);
+
+            LocalIndexStatsImpl combinedIndexStats = new LocalIndexStatsImpl();
+            assertEquals(indexStats1.getHitCount(), indexStats1.getHitCount());
+            combinedIndexStats.setHitCount(indexStats1.getHitCount());
+            combinedIndexStats.setEntryCount(indexStats1.getEntryCount() + indexStats2.getEntryCount());
+
+            assertEquals(indexStats1.getQueryCount(), indexStats1.getQueryCount());
+            combinedIndexStats.setQueryCount(indexStats1.getQueryCount());
+            combinedIndexStats.setAverageHitSelectivity(
+                    (indexStats1.getAverageHitSelectivity() + indexStats2.getAverageHitSelectivity()) / 2.0);
+            combinedIndexStats
+                    .setAverageHitLatency((indexStats1.getAverageHitLatency() + indexStats2.getAverageHitLatency()) / 2);
+
+            combinedIndexStats.setInsertCount(indexStats1.getInsertCount() + indexStats2.getInsertCount());
+            combinedIndexStats.setTotalInsertLatency(indexStats1.getTotalInsertLatency() + indexStats2.getTotalInsertLatency());
+
+            combinedIndexStats.setUpdateCount(indexStats1.getUpdateCount() + indexStats2.getUpdateCount());
+            combinedIndexStats.setTotalUpdateLatency(indexStats1.getTotalUpdateLatency() + indexStats2.getTotalUpdateLatency());
+
+            combinedIndexStats.setRemoveCount(indexStats1.getRemoveCount() + indexStats2.getRemoveCount());
+            combinedIndexStats.setTotalRemoveLatency(indexStats1.getTotalRemoveLatency() + indexStats2.getTotalRemoveLatency());
+
+            combinedIndexStats.setOnHeapMemoryCost(indexStats1.getOnHeapMemoryCost() + indexStats2.getOnHeapMemoryCost());
+            combinedIndexStats.setOffHeapMemoryCost(indexStats1.getOffHeapMemoryCost() + indexStats2.getOffHeapMemoryCost());
+
+            combinedIndexStatsMap.put(indexEntry.getKey(), combinedIndexStats);
+        }
+        combinedStats.setIndexStats(combinedIndexStatsMap);
+
+        return combinedStats;
+    }
+
+}

--- a/hazelcast/src/main/java/com/hazelcast/internal/metrics/metricsets/StatisticsAwareMetricsSet.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/metrics/metricsets/StatisticsAwareMetricsSet.java
@@ -19,6 +19,7 @@ package com.hazelcast.internal.metrics.metricsets;
 import com.hazelcast.cache.CacheStatistics;
 import com.hazelcast.internal.metrics.MetricsRegistry;
 import com.hazelcast.logging.ILogger;
+import com.hazelcast.monitor.LocalIndexStats;
 import com.hazelcast.monitor.LocalInstanceStats;
 import com.hazelcast.monitor.LocalMapStats;
 import com.hazelcast.monitor.NearCacheStats;
@@ -116,6 +117,14 @@ public class StatisticsAwareMetricsSet {
                     if (nearCacheStats != null) {
                         metricsRegistry.scanAndRegister(nearCacheStats,
                                 baseName + "[" + name + "].nearcache");
+                    }
+
+                    if (localInstanceStats instanceof LocalMapStatsImpl) {
+                        Map<String, LocalIndexStats> indexStats = ((LocalMapStatsImpl) localInstanceStats).getIndexStats();
+                        for (Map.Entry<String, LocalIndexStats> indexEntry : indexStats.entrySet()) {
+                            metricsRegistry.scanAndRegister(indexEntry.getValue(),
+                                    baseName + "[" + name + "].index[" + indexEntry.getKey() + "]");
+                        }
                     }
 
                     metricsRegistry.scanAndRegister(localInstanceStats,

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/LocalMapStatsProvider.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/LocalMapStatsProvider.java
@@ -69,11 +69,12 @@ public class LocalMapStatsProvider {
     private final MapNearCacheManager mapNearCacheManager;
     private final IPartitionService partitionService;
     private final ConcurrentMap<String, LocalMapStatsImpl> statsMap = new ConcurrentHashMap<String, LocalMapStatsImpl>(1000);
-    private final ConstructorFunction<String, LocalMapStatsImpl> constructorFunction = new ConstructorFunction<String, LocalMapStatsImpl>() {
-        public LocalMapStatsImpl createNew(String key) {
-            return new LocalMapStatsImpl();
-        }
-    };
+    private final ConstructorFunction<String, LocalMapStatsImpl> constructorFunction =
+            new ConstructorFunction<String, LocalMapStatsImpl>() {
+                public LocalMapStatsImpl createNew(String key) {
+                    return new LocalMapStatsImpl();
+                }
+            };
 
     public LocalMapStatsProvider(MapServiceContext mapServiceContext) {
         this.mapServiceContext = mapServiceContext;

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/MapContainer.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/MapContainer.java
@@ -133,9 +133,7 @@ public class MapContainer {
         initWanReplication(nodeEngine);
         this.extractors = new Extractors(mapConfig.getMapAttributeConfigs(), config.getClassLoader());
         if (shouldUseGlobalIndex(mapConfig)) {
-            this.globalIndexes = new Indexes((InternalSerializationService) serializationService,
-                    mapServiceContext.getIndexProvider(mapConfig), extractors,
-                    true, mapServiceContext.getIndexCopyBehavior());
+            this.globalIndexes = Indexes.createGlobalIndexes(this);
         } else {
             this.globalIndexes = null;
         }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/PartitionContainer.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/PartitionContainer.java
@@ -18,11 +18,8 @@ package com.hazelcast.map.impl;
 
 import com.hazelcast.concurrent.lock.LockService;
 import com.hazelcast.config.MapConfig;
-import com.hazelcast.internal.serialization.InternalSerializationService;
-import com.hazelcast.map.impl.query.IndexProvider;
 import com.hazelcast.map.impl.recordstore.RecordStore;
 import com.hazelcast.query.impl.Indexes;
-import com.hazelcast.query.impl.getters.Extractors;
 import com.hazelcast.spi.ExecutionService;
 import com.hazelcast.spi.NodeEngine;
 import com.hazelcast.spi.ObjectNamespace;
@@ -115,11 +112,8 @@ public class PartitionContainer {
         keyLoader.setHasBackup(mapConfig.getTotalBackupCount() > 0);
         keyLoader.setMapOperationProvider(serviceContext.getMapOperationProvider(name));
 
-        InternalSerializationService ss = (InternalSerializationService) nodeEngine.getSerializationService();
-        IndexProvider indexProvider = serviceContext.getIndexProvider(mapConfig);
         if (!mapContainer.isGlobalIndexEnabled()) {
-            Indexes indexesForMap = new Indexes(ss, indexProvider, mapContainer.getExtractors(), false,
-                    serviceContext.getIndexCopyBehavior());
+            Indexes indexesForMap = Indexes.createPartitionIndexes(mapContainer);
             indexes.putIfAbsent(name, indexesForMap);
         }
         RecordStore recordStore = serviceContext.createRecordStore(mapContainer, partitionId, keyLoader);
@@ -260,11 +254,7 @@ public class PartitionContainer {
                 throw new IllegalStateException("Can't use a partitioned-index in the context of a global-index.");
             }
 
-            InternalSerializationService ss = (InternalSerializationService)
-                    mapServiceContext.getNodeEngine().getSerializationService();
-            Extractors extractors = mapServiceContext.getMapContainer(name).getExtractors();
-            IndexProvider indexProvider = mapServiceContext.getIndexProvider(mapContainer.getMapConfig());
-            Indexes indexesForMap = new Indexes(ss, indexProvider, extractors, false, mapServiceContext.getIndexCopyBehavior());
+            Indexes indexesForMap = Indexes.createPartitionIndexes(mapContainer);
             ixs = indexes.putIfAbsent(name, indexesForMap);
             if (ixs == null) {
                 ixs = indexesForMap;

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/query/DefaultIndexProvider.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/query/DefaultIndexProvider.java
@@ -17,15 +17,21 @@
 package com.hazelcast.map.impl.query;
 
 import com.hazelcast.internal.serialization.InternalSerializationService;
-import com.hazelcast.query.impl.Index;
+import com.hazelcast.monitor.impl.InternalIndexStats;
 import com.hazelcast.query.impl.IndexCopyBehavior;
 import com.hazelcast.query.impl.IndexImpl;
+import com.hazelcast.query.impl.InternalIndex;
 import com.hazelcast.query.impl.getters.Extractors;
 
+/**
+ * Provides on-heap indexes.
+ */
 public class DefaultIndexProvider implements IndexProvider {
+
     @Override
-    public Index createIndex(String attributeName, boolean ordered, Extractors extractors,
-                             InternalSerializationService ss, IndexCopyBehavior copyBehavior) {
-        return new IndexImpl(attributeName, ordered, ss, extractors, copyBehavior);
+    public InternalIndex createIndex(String attributeName, boolean ordered, Extractors extractors,
+                                     InternalSerializationService ss, IndexCopyBehavior copyBehavior, InternalIndexStats stats) {
+        return new IndexImpl(attributeName, ordered, ss, extractors, copyBehavior, stats);
     }
+
 }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/query/IndexProvider.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/query/IndexProvider.java
@@ -17,13 +17,34 @@
 package com.hazelcast.map.impl.query;
 
 import com.hazelcast.internal.serialization.InternalSerializationService;
-import com.hazelcast.query.impl.Index;
+import com.hazelcast.monitor.impl.InternalIndexStats;
 import com.hazelcast.query.impl.IndexCopyBehavior;
+import com.hazelcast.query.impl.InternalIndex;
 import com.hazelcast.query.impl.getters.Extractors;
 
+/**
+ * Provides storage-specific indexes to {@link com.hazelcast.query.impl.Indexes
+ * Indexes}.
+ */
 public interface IndexProvider {
 
-    Index createIndex(String attributeName, boolean ordered, Extractors extractors,
-                      InternalSerializationService ss, IndexCopyBehavior copyBehavior);
+    /**
+     * Creates a new index for the given attribute name.
+     *
+     * @param attributeName the attribute name to create the index for.
+     * @param ordered       {@code true} to create an ordered index supporting
+     *                      fast range queries, {@code false} to create an
+     *                      unordered index supporting fast point queries only.
+     * @param extractors    the extractors to extract values of the given
+     *                      attribute.
+     * @param ss            the serialization service to perform the
+     *                      deserialization of entries while extracting values
+     *                      from them.
+     * @param copyBehavior  the desired index copy behaviour.
+     * @param stats         the index stats instance to report the statistics to.
+     * @return the created index instance.
+     */
+    InternalIndex createIndex(String attributeName, boolean ordered, Extractors extractors, InternalSerializationService ss,
+                              IndexCopyBehavior copyBehavior, InternalIndexStats stats);
 
 }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/query/QueryPartitionOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/query/QueryPartitionOperation.java
@@ -20,6 +20,7 @@ import com.hazelcast.map.impl.MapDataSerializerHook;
 import com.hazelcast.map.impl.operation.MapOperation;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
+import com.hazelcast.query.impl.Indexes;
 import com.hazelcast.spi.PartitionAwareOperation;
 import com.hazelcast.spi.ReadonlyOperation;
 
@@ -43,6 +44,11 @@ public class QueryPartitionOperation extends MapOperation implements PartitionAw
         QueryRunner queryRunner = mapServiceContext.getMapQueryRunner(getName());
         // partition scan only, since we can't run partition queries on global indexes
         result = queryRunner.runPartitionScanQueryOnGivenOwnedPartition(query, getPartitionId());
+
+        // we have to increment query count here manually since we are not even
+        // trying to use indexes
+        Indexes indexes = mapServiceContext.getMapContainer(getName()).getIndexes();
+        indexes.getIndexesStats().incrementQueryCount();
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/subscriber/AbstractInternalQueryCache.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/subscriber/AbstractInternalQueryCache.java
@@ -75,8 +75,7 @@ abstract class AbstractInternalQueryCache<K, V> implements InternalQueryCache<K,
         // We are not using injected index provider since we're not supporting off-heap indexes in CQC due
         // to threading incompatibility. If we injected the IndexProvider from the MapServiceContext
         // the EE side would create HD indexes which is undesired.
-        this.indexes = new Indexes(serializationService, new DefaultIndexProvider(), Extractors.empty(), true,
-                IndexCopyBehavior.COPY_ON_READ);
+        this.indexes = Indexes.createStandaloneIndexes(serializationService, IndexCopyBehavior.COPY_ON_READ);
         this.includeValue = isIncludeValue();
         this.partitioningStrategy = getPartitioningStrategy();
         this.recordStore = new DefaultQueryCacheRecordStore(serializationService, indexes, getQueryCacheConfig(),

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/subscriber/AbstractInternalQueryCache.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/subscriber/AbstractInternalQueryCache.java
@@ -23,7 +23,6 @@ import com.hazelcast.core.PartitioningStrategy;
 import com.hazelcast.internal.eviction.EvictionListener;
 import com.hazelcast.internal.serialization.InternalSerializationService;
 import com.hazelcast.map.impl.proxy.MapProxyImpl;
-import com.hazelcast.map.impl.query.DefaultIndexProvider;
 import com.hazelcast.map.impl.querycache.QueryCacheConfigurator;
 import com.hazelcast.map.impl.querycache.QueryCacheContext;
 import com.hazelcast.map.impl.querycache.QueryCacheEventService;

--- a/hazelcast/src/main/java/com/hazelcast/monitor/LocalIndexStats.java
+++ b/hazelcast/src/main/java/com/hazelcast/monitor/LocalIndexStats.java
@@ -1,0 +1,122 @@
+package com.hazelcast.monitor;
+
+/**
+ * Provides local statistics for an index to be used by {@link MemberState}
+ * implementations.
+ */
+public interface LocalIndexStats extends LocalInstanceStats {
+
+    /**
+     * Returns the current number of entries indexed by the index.
+     */
+    long getEntryCount();
+
+    /**
+     * Returns the total number of queries served by the index.
+     * <p>
+     * To calculate the index hit rate just divide the returned value by a value
+     * returned by {@link LocalMapStats#getQueryCount()}.
+     * <p>
+     * The returned value may be less than the one returned by {@link
+     * #getHitCount()} since a single query may hit the same index more than once.
+     * <p>
+     * Following operations counted as a query:
+     * <ul>
+     * <li>{@link com.hazelcast.query.impl.Index#getRecords(Comparable) Index.getRecords(Comparable)}
+     * <li>{@link com.hazelcast.query.impl.Index#getRecords(Comparable[]) Index.getRecords(Comparable[])}
+     * <li>{@link com.hazelcast.query.impl.Index#getSubRecords Index.getSubRecords}
+     * <li>{@link com.hazelcast.query.impl.Index#getSubRecordsBetween Index.getSubRecordsBetween}
+     * </ul>
+     */
+    long getQueryCount();
+
+    /**
+     * Returns the total number of hits into the index.
+     * <p>
+     * The returned value may be greater than the one returned by {@link
+     * #getQueryCount} since a single query may hit the same index more than once.
+     * <p>
+     * Following operations generate a hit:
+     * <ul>
+     * <li>{@link com.hazelcast.query.impl.Index#getRecords(Comparable) Index.getRecords(Comparable)}
+     * <li>{@link com.hazelcast.query.impl.Index#getRecords(Comparable[]) Index.getRecords(Comparable[])}
+     * <li>{@link com.hazelcast.query.impl.Index#getSubRecords Index.getSubRecords}
+     * <li>{@link com.hazelcast.query.impl.Index#getSubRecordsBetween Index.getSubRecordsBetween}
+     * </ul>
+     */
+    long getHitCount();
+
+    /**
+     * Returns the average hit latency for the index.
+     */
+    long getAverageHitLatency();
+
+    /**
+     * Returns the average selectivity of the hits served by the index.
+     * <p>
+     * The returned value is in the range from 0.0 to 1.0. Values close to 1.0
+     * indicate a high selectivity meaning the index is efficient; values close
+     * to 0.0 indicate a low selectivity meaning the index efficiency is
+     * approaching an efficiency of a simple full scan.
+     */
+    double getAverageHitSelectivity();
+
+    /**
+     * Returns the number of insert operations performed on the index.
+     */
+    long getInsertCount();
+
+    /**
+     * Returns the total latency (in nanoseconds) of insert operations performed
+     * on the index.
+     * <p>
+     * To compute the average latency divide the returned value by {@link
+     * #getInsertCount() insert operation count}.
+     */
+    long getTotalInsertLatency();
+
+    /**
+     * Returns the number of update operations performed on the index.
+     */
+    long getUpdateCount();
+
+    /**
+     * Returns the total latency (in nanoseconds) of update operations performed
+     * on the index.
+     * <p>
+     * To compute the average latency divide the returned value by {@link
+     * #getUpdateCount() update operation count}.
+     */
+    long getTotalUpdateLatency();
+
+    /**
+     * Returns the number of remove operations performed on the index.
+     */
+    long getRemoveCount();
+
+    /**
+     * Returns the total latency (in nanoseconds) of remove operations performed
+     * on the index.
+     * <p>
+     * To compute the average latency divide the returned value by {@link
+     * #getRemoveCount() remove operation count}.
+     */
+    long getTotalRemoveLatency();
+
+    /**
+     * Returns the on-heap memory cost of the index in bytes.
+     * <p>
+     * Currently, the returned value is just a best-effort approximation and
+     * doesn't indicate the precise on-heap memory usage of the index.
+     */
+    long getOnHeapMemoryCost();
+
+    /**
+     * Returns the off-heap memory cost of the index in bytes.
+     * <p>
+     * The returned value includes all active off-heap allocations associated
+     * with the index.
+     */
+    long getOffHeapMemoryCost();
+
+}

--- a/hazelcast/src/main/java/com/hazelcast/monitor/LocalIndexStats.java
+++ b/hazelcast/src/main/java/com/hazelcast/monitor/LocalIndexStats.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.hazelcast.monitor;
 
 /**

--- a/hazelcast/src/main/java/com/hazelcast/monitor/LocalMapStats.java
+++ b/hazelcast/src/main/java/com/hazelcast/monitor/LocalMapStats.java
@@ -16,6 +16,8 @@
 
 package com.hazelcast.monitor;
 
+import java.util.Map;
+
 /**
  * Local map statistics to be used by {@link MemberState} implementations.
  * <p>
@@ -210,4 +212,20 @@ public interface LocalMapStats extends LocalInstanceStats {
      * @return statistics object for the Near Cache
      */
     NearCacheStats getNearCacheStats();
+
+    /**
+     * Returns the number of queries performed on the map.
+     */
+    long getQueryCount();
+
+    /**
+     * Returns the number of indexed queries performed on the map.
+     */
+    long getIndexedQueryCount();
+
+    /**
+     * Returns the per-index statistics map keyed by the index name.
+     */
+    Map<String, LocalIndexStats> getIndexStats();
+
 }

--- a/hazelcast/src/main/java/com/hazelcast/monitor/impl/GlobalIndexStats.java
+++ b/hazelcast/src/main/java/com/hazelcast/monitor/impl/GlobalIndexStats.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.hazelcast.monitor.impl;
 
 import com.hazelcast.internal.memory.MemoryAllocator;
@@ -57,18 +73,18 @@ public class GlobalIndexStats implements InternalIndexStats {
     private final boolean queryableEntriesAreCached;
     private final long creationTime;
 
-    private volatile long entryCount = 0;
-    private volatile long queryCount = 0;
-    private volatile long hitCount = 0;
-    private volatile long totalHitLatency = 0;
-    private volatile long totalNormalizedHitCardinality = 0;
-    private volatile long insertCount = 0;
-    private volatile long totalInsertLatency = 0;
-    private volatile long updateCount = 0;
-    private volatile long totalUpdateLatency = 0;
-    private volatile long removeCount = 0;
-    private volatile long totalRemoveLatency = 0;
-    private volatile long valuesMemoryCost = 0;
+    private volatile long entryCount;
+    private volatile long queryCount;
+    private volatile long hitCount;
+    private volatile long totalHitLatency;
+    private volatile long totalNormalizedHitCardinality;
+    private volatile long insertCount;
+    private volatile long totalInsertLatency;
+    private volatile long updateCount;
+    private volatile long totalUpdateLatency;
+    private volatile long removeCount;
+    private volatile long totalRemoveLatency;
+    private volatile long valuesMemoryCost;
 
     /**
      * Constructs a new instance of global index stats.

--- a/hazelcast/src/main/java/com/hazelcast/monitor/impl/GlobalIndexStats.java
+++ b/hazelcast/src/main/java/com/hazelcast/monitor/impl/GlobalIndexStats.java
@@ -1,0 +1,235 @@
+package com.hazelcast.monitor.impl;
+
+import com.hazelcast.internal.memory.MemoryAllocator;
+import com.hazelcast.query.impl.IndexHeapMemoryCostUtil;
+import com.hazelcast.util.Clock;
+
+import java.util.concurrent.atomic.AtomicLongFieldUpdater;
+
+import static java.util.concurrent.atomic.AtomicLongFieldUpdater.newUpdater;
+
+/**
+ * The implementation of internal index stats specialized for global indexes.
+ * <p>
+ * The main trait of the implementation is the concurrency support, which is
+ * required for global indexes because they are shared among partitions.
+ */
+public class GlobalIndexStats implements InternalIndexStats {
+
+    // To compute the average hit cardinality we need to track the total
+    // cardinality of all of the hits and then divide it by the number of hits.
+    // But since the number of the indexed entries may change with time, this
+    // raw total cardinality value can't provide any useful information. So
+    // instead we store the total normalized cardinality, which sums up the
+    // individual hit cardinalities divided by the index size at the time of the
+    // hit. This total normalized cardinality is a floating point number with
+    // which we can't work easily: we need to perform atomic operations on it
+    // since global index stats are shared among all map partitions, but there
+    // is no notion of atomic operations for doubles/floats. To overcome this
+    // problem we store a scaled long representation which gives around 1%
+    // precision.
+    private static final long PRECISION_SCALE = 7;
+    private static final long PRECISION = 1 << PRECISION_SCALE;
+
+    private static final AtomicLongFieldUpdater<GlobalIndexStats> ENTRY_COUNT = newUpdater(GlobalIndexStats.class, "entryCount");
+    private static final AtomicLongFieldUpdater<GlobalIndexStats> QUERY_COUNT = newUpdater(GlobalIndexStats.class, "queryCount");
+    private static final AtomicLongFieldUpdater<GlobalIndexStats> HIT_COUNT = newUpdater(GlobalIndexStats.class, "hitCount");
+    private static final AtomicLongFieldUpdater<GlobalIndexStats> TOTAL_HIT_LATENCY = newUpdater(GlobalIndexStats.class,
+            "totalHitLatency");
+    private static final AtomicLongFieldUpdater<GlobalIndexStats> TOTAL_NORMALIZED_HIT_CARDINALITY = newUpdater(
+            GlobalIndexStats.class, "totalNormalizedHitCardinality");
+    private static final AtomicLongFieldUpdater<GlobalIndexStats> INSERT_COUNT = newUpdater(GlobalIndexStats.class,
+            "insertCount");
+    private static final AtomicLongFieldUpdater<GlobalIndexStats> TOTAL_INSERT_LATENCY = newUpdater(GlobalIndexStats.class,
+            "totalInsertLatency");
+    private static final AtomicLongFieldUpdater<GlobalIndexStats> UPDATE_COUNT = newUpdater(GlobalIndexStats.class,
+            "updateCount");
+    private static final AtomicLongFieldUpdater<GlobalIndexStats> TOTAL_UPDATE_LATENCY = newUpdater(GlobalIndexStats.class,
+            "totalUpdateLatency");
+    private static final AtomicLongFieldUpdater<GlobalIndexStats> REMOVE_COUNT = newUpdater(GlobalIndexStats.class,
+            "removeCount");
+    private static final AtomicLongFieldUpdater<GlobalIndexStats> TOTAL_REMOVE_LATENCY = newUpdater(GlobalIndexStats.class,
+            "totalRemoveLatency");
+    private static final AtomicLongFieldUpdater<GlobalIndexStats> VALUES_MEMORY_COST = newUpdater(GlobalIndexStats.class,
+            "valuesMemoryCost");
+
+    private final boolean ordered;
+    private final boolean queryableEntriesAreCached;
+    private final long creationTime;
+
+    private volatile long entryCount = 0;
+    private volatile long queryCount = 0;
+    private volatile long hitCount = 0;
+    private volatile long totalHitLatency = 0;
+    private volatile long totalNormalizedHitCardinality = 0;
+    private volatile long insertCount = 0;
+    private volatile long totalInsertLatency = 0;
+    private volatile long updateCount = 0;
+    private volatile long totalUpdateLatency = 0;
+    private volatile long removeCount = 0;
+    private volatile long totalRemoveLatency = 0;
+    private volatile long valuesMemoryCost = 0;
+
+    /**
+     * Constructs a new instance of global index stats.
+     *
+     * @param ordered                   {@code true} if the stats are being created
+     *                                  for an ordered index, {@code false} otherwise.
+     *                                  Affects the on-heap memory cost calculation.
+     * @param queryableEntriesAreCached {@code true} if the stats are being created
+     *                                  for an index for which queryable entries are
+     *                                  cached, {@code false} otherwise. Affects the
+     *                                  on-heap memory cost calculation.
+     */
+    public GlobalIndexStats(boolean ordered, boolean queryableEntriesAreCached) {
+        this.ordered = ordered;
+        this.queryableEntriesAreCached = queryableEntriesAreCached;
+        this.creationTime = Clock.currentTimeMillis();
+    }
+
+    @Override
+    public long makeTimestamp() {
+        return System.nanoTime();
+    }
+
+    @Override
+    public long getCreationTime() {
+        return creationTime;
+    }
+
+    @Override
+    public long getEntryCount() {
+        return entryCount;
+    }
+
+    @Override
+    public long getQueryCount() {
+        return queryCount;
+    }
+
+    @Override
+    public void incrementQueryCount() {
+        QUERY_COUNT.incrementAndGet(this);
+    }
+
+    @Override
+    public long getHitCount() {
+        return hitCount;
+    }
+
+    @Override
+    public long getTotalHitLatency() {
+        return totalHitLatency;
+    }
+
+    @Override
+    public double getTotalNormalizedHitCardinality() {
+        return (double) totalNormalizedHitCardinality / PRECISION;
+    }
+
+    @Override
+    public long getInsertCount() {
+        return insertCount;
+    }
+
+    @Override
+    public long getTotalInsertLatency() {
+        return totalInsertLatency;
+    }
+
+    @Override
+    public long getUpdateCount() {
+        return updateCount;
+    }
+
+    @Override
+    public long getTotalUpdateLatency() {
+        return totalUpdateLatency;
+    }
+
+    @Override
+    public long getRemoveCount() {
+        return removeCount;
+    }
+
+    @Override
+    public long getTotalRemoveLatency() {
+        return totalRemoveLatency;
+    }
+
+    @Override
+    public long getOnHeapMemoryCost() {
+        return IndexHeapMemoryCostUtil.estimateMapCost(entryCount, ordered, queryableEntriesAreCached) + valuesMemoryCost;
+    }
+
+    @Override
+    public long getOffHeapMemoryCost() {
+        return 0;
+    }
+
+    @Override
+    public void onEntryInserted(long timestamp, Object value) {
+        TOTAL_INSERT_LATENCY.addAndGet(this, System.nanoTime() - timestamp);
+        INSERT_COUNT.incrementAndGet(this);
+        ENTRY_COUNT.incrementAndGet(this);
+        VALUES_MEMORY_COST.addAndGet(this, IndexHeapMemoryCostUtil.estimateValueCost(value));
+    }
+
+    @Override
+    public void onEntryUpdated(long timestamp, Object oldValue, Object newValue) {
+        TOTAL_UPDATE_LATENCY.addAndGet(this, System.nanoTime() - timestamp);
+        UPDATE_COUNT.incrementAndGet(this);
+        long oldCost = IndexHeapMemoryCostUtil.estimateValueCost(oldValue);
+        long newCost = IndexHeapMemoryCostUtil.estimateValueCost(newValue);
+        VALUES_MEMORY_COST.addAndGet(this, newCost - oldCost);
+    }
+
+    @Override
+    public void onEntryRemoved(long timestamp, Object value) {
+        TOTAL_REMOVE_LATENCY.addAndGet(this, System.nanoTime() - timestamp);
+        REMOVE_COUNT.incrementAndGet(this);
+        ENTRY_COUNT.decrementAndGet(this);
+        VALUES_MEMORY_COST.addAndGet(this, -IndexHeapMemoryCostUtil.estimateValueCost(value));
+    }
+
+    @Override
+    public void onEntriesCleared() {
+        entryCount = 0;
+        valuesMemoryCost = 0;
+    }
+
+    @Override
+    public void onIndexHit(long timestamp, long hitCardinality) {
+        long localEntryCount = entryCount;
+        if (localEntryCount == 0) {
+            // selecting nothing from nothing is not counted as a hit
+            return;
+        }
+
+        TOTAL_HIT_LATENCY.addAndGet(this, System.nanoTime() - timestamp);
+        HIT_COUNT.incrementAndGet(this);
+
+        // limit the cardinality for "safety"
+        long adjustedHitCardinality = Math.min(hitCardinality, localEntryCount);
+
+        // scale the cardinality to maintain the precision
+        long scaledHitCardinality = adjustedHitCardinality << PRECISION_SCALE;
+
+        // this will produce a value in [0, PRECISION] range
+        long normalizedHitCardinality = scaledHitCardinality / localEntryCount;
+
+        TOTAL_NORMALIZED_HIT_CARDINALITY.addAndGet(this, normalizedHitCardinality);
+    }
+
+    @Override
+    public void resetPerQueryStats() {
+        // Do nothing, per-query stats are tracked in GlobalQueryContextWithStats
+        // since this stats instance is shared among queries.
+    }
+
+    @Override
+    public MemoryAllocator wrapMemoryAllocator(MemoryAllocator memoryAllocator) {
+        throw new UnsupportedOperationException("global indexes are not supposed to use native memory allocators");
+    }
+
+}

--- a/hazelcast/src/main/java/com/hazelcast/monitor/impl/GlobalIndexesStats.java
+++ b/hazelcast/src/main/java/com/hazelcast/monitor/impl/GlobalIndexesStats.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.hazelcast.monitor.impl;
 
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
@@ -17,8 +33,8 @@ public class GlobalIndexesStats implements InternalIndexesStats {
     private static final AtomicLongFieldUpdater<GlobalIndexesStats> INDEXED_QUERY_COUNT = newUpdater(GlobalIndexesStats.class,
             "indexedQueryCount");
 
-    private volatile long queryCount = 0;
-    private volatile long indexedQueryCount = 0;
+    private volatile long queryCount;
+    private volatile long indexedQueryCount;
 
     @Override
     public long getQueryCount() {

--- a/hazelcast/src/main/java/com/hazelcast/monitor/impl/GlobalIndexesStats.java
+++ b/hazelcast/src/main/java/com/hazelcast/monitor/impl/GlobalIndexesStats.java
@@ -1,0 +1,48 @@
+package com.hazelcast.monitor.impl;
+
+import java.util.concurrent.atomic.AtomicLongFieldUpdater;
+
+import static java.util.concurrent.atomic.AtomicLongFieldUpdater.newUpdater;
+
+/**
+ * The implementation of internal indexes stats specialized for global indexes.
+ * <p>
+ * The main trait of the implementation is the concurrency support, which is
+ * required for global indexes because they are shared among partitions.
+ */
+public class GlobalIndexesStats implements InternalIndexesStats {
+
+    private static final AtomicLongFieldUpdater<GlobalIndexesStats> QUERY_COUNT = newUpdater(GlobalIndexesStats.class,
+            "queryCount");
+    private static final AtomicLongFieldUpdater<GlobalIndexesStats> INDEXED_QUERY_COUNT = newUpdater(GlobalIndexesStats.class,
+            "indexedQueryCount");
+
+    private volatile long queryCount = 0;
+    private volatile long indexedQueryCount = 0;
+
+    @Override
+    public long getQueryCount() {
+        return queryCount;
+    }
+
+    @Override
+    public void incrementQueryCount() {
+        QUERY_COUNT.incrementAndGet(this);
+    }
+
+    @Override
+    public long getIndexedQueryCount() {
+        return indexedQueryCount;
+    }
+
+    @Override
+    public void incrementIndexedQueryCount() {
+        INDEXED_QUERY_COUNT.incrementAndGet(this);
+    }
+
+    @Override
+    public InternalIndexStats createIndexStats(boolean ordered, boolean queryableEntriesAreCached) {
+        return new GlobalIndexStats(ordered, queryableEntriesAreCached);
+    }
+
+}

--- a/hazelcast/src/main/java/com/hazelcast/monitor/impl/InternalIndexStats.java
+++ b/hazelcast/src/main/java/com/hazelcast/monitor/impl/InternalIndexStats.java
@@ -1,0 +1,318 @@
+package com.hazelcast.monitor.impl;
+
+import com.hazelcast.internal.memory.MemoryAllocator;
+
+/**
+ * Provides internal per-index statistics for {@link com.hazelcast.query.impl.Index
+ * Index}.
+ */
+public interface InternalIndexStats {
+
+    /**
+     * Returns a new timestamp.
+     * <p>
+     * Used for latency measurement, expressed in nanoseconds.
+     */
+    long makeTimestamp();
+
+    /**
+     * Returns the creation time of the index.
+     * <p>
+     * The value is relative to midnight, January 1, 1970 UTC and expressed in
+     * milliseconds.
+     */
+    long getCreationTime();
+
+    /**
+     * Returns the current number of entries indexed by the index.
+     */
+    long getEntryCount();
+
+    /**
+     * Returns the total number of queries served by the index.
+     * <p>
+     * The returned value may be less than the one returned by {@link
+     * #getHitCount()} since a single query may hit the same index more than once.
+     */
+    long getQueryCount();
+
+    /**
+     * Increments the query count for the index.
+     */
+    void incrementQueryCount();
+
+    /**
+     * Returns the total number of hits into the index.
+     * <p>
+     * The returned value may be greater than the one returned by {@link
+     * #getQueryCount} since a single query may hit the same index more than once.
+     */
+    long getHitCount();
+
+    /**
+     * Returns the total hit latency for the index.
+     */
+    long getTotalHitLatency();
+
+    /**
+     * Returns the total normalized cardinality of the hits served by the index.
+     * <p>
+     * Normalized hit cardinality is calculated as {@code hit_cardinality /
+     * entry_count} at the time of the hit. The returned value is a sum of all
+     * individual normalized hit cardinalities.
+     */
+    double getTotalNormalizedHitCardinality();
+
+    /**
+     * Returns the number of insert operations performed on the index.
+     */
+    long getInsertCount();
+
+    /**
+     * Returns the total latency (in nanoseconds) of insert operations performed
+     * on the index.
+     * <p>
+     * To compute the average latency divide the returned value by {@link
+     * #getInsertCount() insert operation count}.
+     */
+    long getTotalInsertLatency();
+
+    /**
+     * Returns the number of update operations performed on the index.
+     */
+    long getUpdateCount();
+
+    /**
+     * Returns the total latency (in nanoseconds) of update operations performed
+     * on the index.
+     * <p>
+     * To compute the average latency divide the returned value by {@link
+     * #getUpdateCount() update operation count}.
+     */
+    long getTotalUpdateLatency();
+
+    /**
+     * Returns the number of remove operations performed on the index.
+     */
+    long getRemoveCount();
+
+    /**
+     * Returns the total latency (in nanoseconds) of remove operations performed
+     * on the index.
+     * <p>
+     * To compute the average latency divide the returned value by {@link
+     * #getRemoveCount() remove operation count}.
+     */
+    long getTotalRemoveLatency();
+
+    /**
+     * Returns the on-heap memory cost of the index in bytes.
+     * <p>
+     * Currently, the returned value is just a best-effort approximation and
+     * doesn't indicate the precise on-heap memory usage of the index.
+     */
+    long getOnHeapMemoryCost();
+
+    /**
+     * Returns the off-heap memory cost of the index in bytes.
+     * <p>
+     * The returned value includes all active off-heap allocations associated
+     * with the index.
+     */
+    long getOffHeapMemoryCost();
+
+    /**
+     * Invoked by the associated index after every insert operation.
+     *
+     * @param timestamp the time at which the insert operation was started.
+     * @param value     the value inserted to the index.
+     * @see #makeTimestamp
+     * @see com.hazelcast.query.impl.Index#saveEntryIndex
+     */
+    void onEntryInserted(long timestamp, Object value);
+
+    /**
+     * Invoked by the associated index after every update operation.
+     *
+     * @param timestamp the time at which the update operation was started.
+     * @param oldValue  the old value replaced in the index.
+     * @param newValue  the new value inserted to the index.
+     * @see #makeTimestamp
+     * @see com.hazelcast.query.impl.Index#saveEntryIndex
+     */
+    void onEntryUpdated(long timestamp, Object oldValue, Object newValue);
+
+    /**
+     * Invoked by the associated index after every remove operation.
+     *
+     * @param timestamp the time at which the remove operation was started.
+     * @param value     the value removed from the index.
+     * @see #makeTimestamp
+     * @see com.hazelcast.query.impl.Index#removeEntryIndex
+     */
+    void onEntryRemoved(long timestamp, Object value);
+
+    /**
+     * Invoked by the associated index after the index was cleared.
+     *
+     * @see com.hazelcast.query.impl.Index#clear
+     */
+    void onEntriesCleared();
+
+    /**
+     * Invoked by the associated index after every index hit.
+     * <p>
+     * Following operations generate a hit:
+     * <ul>
+     * <li>{@link com.hazelcast.query.impl.Index#getRecords(Comparable) Index.getRecords(Comparable)}
+     * <li>{@link com.hazelcast.query.impl.Index#getRecords(Comparable[]) Index.getRecords(Comparable[])}
+     * <li>{@link com.hazelcast.query.impl.Index#getSubRecords Index.getSubRecords}
+     * <li>{@link com.hazelcast.query.impl.Index#getSubRecordsBetween Index.getSubRecordsBetween}
+     * </ul>
+     *
+     * @param timestamp      the time at which the hit-producing operation was
+     *                       started.
+     * @param hitCardinality the cardinality of the hit.
+     * @see #makeTimestamp()
+     */
+    void onIndexHit(long timestamp, long hitCardinality);
+
+    /**
+     * Resets the per-query stats, if any, currently tracked by this internal
+     * index stats instance.
+     */
+    void resetPerQueryStats();
+
+    /**
+     * Wraps the given memory allocator.
+     * <p>
+     * Used for the off-heap memory cost tracking.
+     *
+     * @param memoryAllocator the memory allocator to wrap.
+     * @return the wrapped memory allocator.
+     */
+    MemoryAllocator wrapMemoryAllocator(MemoryAllocator memoryAllocator);
+
+    /**
+     * Empty no-op internal index stats instance.
+     */
+    InternalIndexStats EMPTY = new InternalIndexStats() {
+
+        @Override
+        public long makeTimestamp() {
+            return 0;
+        }
+
+        @Override
+        public long getCreationTime() {
+            return 0;
+        }
+
+        @Override
+        public long getEntryCount() {
+            return 0;
+        }
+
+        @Override
+        public long getQueryCount() {
+            return 0;
+        }
+
+        @Override
+        public void incrementQueryCount() {
+            // do nothing
+        }
+
+        @Override
+        public long getHitCount() {
+            return 0;
+        }
+
+        @Override
+        public long getTotalHitLatency() {
+            return 0;
+        }
+
+        @Override
+        public double getTotalNormalizedHitCardinality() {
+            return 0.0;
+        }
+
+        @Override
+        public long getInsertCount() {
+            return 0;
+        }
+
+        @Override
+        public long getTotalInsertLatency() {
+            return 0;
+        }
+
+        @Override
+        public long getUpdateCount() {
+            return 0;
+        }
+
+        @Override
+        public long getTotalUpdateLatency() {
+            return 0;
+        }
+
+        @Override
+        public long getRemoveCount() {
+            return 0;
+        }
+
+        @Override
+        public long getTotalRemoveLatency() {
+            return 0;
+        }
+
+        @Override
+        public long getOnHeapMemoryCost() {
+            return 0;
+        }
+
+        @Override
+        public long getOffHeapMemoryCost() {
+            return 0;
+        }
+
+        @Override
+        public void onEntryInserted(long timestamp, Object value) {
+            // do nothing
+        }
+
+        @Override
+        public void onEntryUpdated(long timestamp, Object oldValue, Object newValue) {
+            // do nothing
+        }
+
+        @Override
+        public void onEntryRemoved(long timestamp, Object value) {
+            // do nothing
+        }
+
+        @Override
+        public void onEntriesCleared() {
+            // do nothing
+        }
+
+        @Override
+        public void onIndexHit(long timestamp, long hitCardinality) {
+            // do nothing
+        }
+
+        @Override
+        public void resetPerQueryStats() {
+            // do nothing
+        }
+
+        @Override
+        public MemoryAllocator wrapMemoryAllocator(MemoryAllocator memoryAllocator) {
+            return memoryAllocator;
+        }
+
+    };
+
+}

--- a/hazelcast/src/main/java/com/hazelcast/monitor/impl/InternalIndexStats.java
+++ b/hazelcast/src/main/java/com/hazelcast/monitor/impl/InternalIndexStats.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.hazelcast.monitor.impl;
 
 import com.hazelcast.internal.memory.MemoryAllocator;
@@ -6,7 +22,130 @@ import com.hazelcast.internal.memory.MemoryAllocator;
  * Provides internal per-index statistics for {@link com.hazelcast.query.impl.Index
  * Index}.
  */
+@SuppressWarnings({"checkstyle:methodcount", "checkstyle:anoninnerlength"})
 public interface InternalIndexStats {
+
+    /**
+     * Empty no-op internal index stats instance.
+     */
+    InternalIndexStats EMPTY = new InternalIndexStats() {
+
+        @Override
+        public long makeTimestamp() {
+            return 0;
+        }
+
+        @Override
+        public long getCreationTime() {
+            return 0;
+        }
+
+        @Override
+        public long getEntryCount() {
+            return 0;
+        }
+
+        @Override
+        public long getQueryCount() {
+            return 0;
+        }
+
+        @Override
+        public void incrementQueryCount() {
+            // do nothing
+        }
+
+        @Override
+        public long getHitCount() {
+            return 0;
+        }
+
+        @Override
+        public long getTotalHitLatency() {
+            return 0;
+        }
+
+        @Override
+        public double getTotalNormalizedHitCardinality() {
+            return 0.0;
+        }
+
+        @Override
+        public long getInsertCount() {
+            return 0;
+        }
+
+        @Override
+        public long getTotalInsertLatency() {
+            return 0;
+        }
+
+        @Override
+        public long getUpdateCount() {
+            return 0;
+        }
+
+        @Override
+        public long getTotalUpdateLatency() {
+            return 0;
+        }
+
+        @Override
+        public long getRemoveCount() {
+            return 0;
+        }
+
+        @Override
+        public long getTotalRemoveLatency() {
+            return 0;
+        }
+
+        @Override
+        public long getOnHeapMemoryCost() {
+            return 0;
+        }
+
+        @Override
+        public long getOffHeapMemoryCost() {
+            return 0;
+        }
+
+        @Override
+        public void onEntryInserted(long timestamp, Object value) {
+            // do nothing
+        }
+
+        @Override
+        public void onEntryUpdated(long timestamp, Object oldValue, Object newValue) {
+            // do nothing
+        }
+
+        @Override
+        public void onEntryRemoved(long timestamp, Object value) {
+            // do nothing
+        }
+
+        @Override
+        public void onEntriesCleared() {
+            // do nothing
+        }
+
+        @Override
+        public void onIndexHit(long timestamp, long hitCardinality) {
+            // do nothing
+        }
+
+        @Override
+        public void resetPerQueryStats() {
+            // do nothing
+        }
+
+        @Override
+        public MemoryAllocator wrapMemoryAllocator(MemoryAllocator memoryAllocator) {
+            return memoryAllocator;
+        }
+
+    };
 
     /**
      * Returns a new timestamp.
@@ -192,127 +331,5 @@ public interface InternalIndexStats {
      * @return the wrapped memory allocator.
      */
     MemoryAllocator wrapMemoryAllocator(MemoryAllocator memoryAllocator);
-
-    /**
-     * Empty no-op internal index stats instance.
-     */
-    InternalIndexStats EMPTY = new InternalIndexStats() {
-
-        @Override
-        public long makeTimestamp() {
-            return 0;
-        }
-
-        @Override
-        public long getCreationTime() {
-            return 0;
-        }
-
-        @Override
-        public long getEntryCount() {
-            return 0;
-        }
-
-        @Override
-        public long getQueryCount() {
-            return 0;
-        }
-
-        @Override
-        public void incrementQueryCount() {
-            // do nothing
-        }
-
-        @Override
-        public long getHitCount() {
-            return 0;
-        }
-
-        @Override
-        public long getTotalHitLatency() {
-            return 0;
-        }
-
-        @Override
-        public double getTotalNormalizedHitCardinality() {
-            return 0.0;
-        }
-
-        @Override
-        public long getInsertCount() {
-            return 0;
-        }
-
-        @Override
-        public long getTotalInsertLatency() {
-            return 0;
-        }
-
-        @Override
-        public long getUpdateCount() {
-            return 0;
-        }
-
-        @Override
-        public long getTotalUpdateLatency() {
-            return 0;
-        }
-
-        @Override
-        public long getRemoveCount() {
-            return 0;
-        }
-
-        @Override
-        public long getTotalRemoveLatency() {
-            return 0;
-        }
-
-        @Override
-        public long getOnHeapMemoryCost() {
-            return 0;
-        }
-
-        @Override
-        public long getOffHeapMemoryCost() {
-            return 0;
-        }
-
-        @Override
-        public void onEntryInserted(long timestamp, Object value) {
-            // do nothing
-        }
-
-        @Override
-        public void onEntryUpdated(long timestamp, Object oldValue, Object newValue) {
-            // do nothing
-        }
-
-        @Override
-        public void onEntryRemoved(long timestamp, Object value) {
-            // do nothing
-        }
-
-        @Override
-        public void onEntriesCleared() {
-            // do nothing
-        }
-
-        @Override
-        public void onIndexHit(long timestamp, long hitCardinality) {
-            // do nothing
-        }
-
-        @Override
-        public void resetPerQueryStats() {
-            // do nothing
-        }
-
-        @Override
-        public MemoryAllocator wrapMemoryAllocator(MemoryAllocator memoryAllocator) {
-            return memoryAllocator;
-        }
-
-    };
 
 }

--- a/hazelcast/src/main/java/com/hazelcast/monitor/impl/InternalIndexesStats.java
+++ b/hazelcast/src/main/java/com/hazelcast/monitor/impl/InternalIndexesStats.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.hazelcast.monitor.impl;
 
 /**
@@ -5,6 +21,36 @@ package com.hazelcast.monitor.impl;
  * Indexes}.
  */
 public interface InternalIndexesStats {
+
+    /**
+     * Empty no-op internal indexes stats.
+     */
+    InternalIndexesStats EMPTY = new InternalIndexesStats() {
+        @Override
+        public long getQueryCount() {
+            return 0;
+        }
+
+        @Override
+        public void incrementQueryCount() {
+            // do nothing
+        }
+
+        @Override
+        public long getIndexedQueryCount() {
+            return 0;
+        }
+
+        @Override
+        public void incrementIndexedQueryCount() {
+            // do nothing
+        }
+
+        @Override
+        public InternalIndexStats createIndexStats(boolean ordered, boolean queryableEntriesAreCached) {
+            return InternalIndexStats.EMPTY;
+        }
+    };
 
     /**
      * Returns the number of queries performed on the indexes.
@@ -37,35 +83,5 @@ public interface InternalIndexesStats {
      * @return the created internal per-index stats instance.
      */
     InternalIndexStats createIndexStats(boolean ordered, boolean queryableEntriesAreCached);
-
-    /**
-     * Empty no-op internal indexes stats.
-     */
-    InternalIndexesStats EMPTY = new InternalIndexesStats() {
-        @Override
-        public long getQueryCount() {
-            return 0;
-        }
-
-        @Override
-        public void incrementQueryCount() {
-            // do nothing
-        }
-
-        @Override
-        public long getIndexedQueryCount() {
-            return 0;
-        }
-
-        @Override
-        public void incrementIndexedQueryCount() {
-            // do nothing
-        }
-
-        @Override
-        public InternalIndexStats createIndexStats(boolean ordered, boolean queryableEntriesAreCached) {
-            return InternalIndexStats.EMPTY;
-        }
-    };
 
 }

--- a/hazelcast/src/main/java/com/hazelcast/monitor/impl/InternalIndexesStats.java
+++ b/hazelcast/src/main/java/com/hazelcast/monitor/impl/InternalIndexesStats.java
@@ -1,0 +1,71 @@
+package com.hazelcast.monitor.impl;
+
+/**
+ * Provides internal statistics for {@link com.hazelcast.query.impl.Indexes
+ * Indexes}.
+ */
+public interface InternalIndexesStats {
+
+    /**
+     * Returns the number of queries performed on the indexes.
+     */
+    long getQueryCount();
+
+    /**
+     * Increments the number of queries performed on the indexes.
+     */
+    void incrementQueryCount();
+
+    /**
+     * Returns the number of indexed queries performed on the indexes.
+     */
+    long getIndexedQueryCount();
+
+    /**
+     * Increments the number of indexed queries performed on the indexes.
+     */
+    void incrementIndexedQueryCount();
+
+    /**
+     * Creates a new instance of internal per-index stats.
+     *
+     * @param ordered                   {@code true} if the stats are being created
+     *                                  for an ordered index, {@code false} otherwise.
+     * @param queryableEntriesAreCached {@code true} if the stats are being created
+     *                                  for an index for which queryable entries are
+     *                                  cached, {@code false} otherwise.
+     * @return the created internal per-index stats instance.
+     */
+    InternalIndexStats createIndexStats(boolean ordered, boolean queryableEntriesAreCached);
+
+    /**
+     * Empty no-op internal indexes stats.
+     */
+    InternalIndexesStats EMPTY = new InternalIndexesStats() {
+        @Override
+        public long getQueryCount() {
+            return 0;
+        }
+
+        @Override
+        public void incrementQueryCount() {
+            // do nothing
+        }
+
+        @Override
+        public long getIndexedQueryCount() {
+            return 0;
+        }
+
+        @Override
+        public void incrementIndexedQueryCount() {
+            // do nothing
+        }
+
+        @Override
+        public InternalIndexStats createIndexStats(boolean ordered, boolean queryableEntriesAreCached) {
+            return InternalIndexStats.EMPTY;
+        }
+    };
+
+}

--- a/hazelcast/src/main/java/com/hazelcast/monitor/impl/LocalIndexStatsImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/monitor/impl/LocalIndexStatsImpl.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.hazelcast.monitor.impl;
 
 import com.eclipsesource.json.JsonObject;
@@ -8,49 +24,50 @@ import com.hazelcast.monitor.LocalIndexStats;
  * Implementation of local index stats that backs the stats exposed through the
  * public API.
  */
+@SuppressWarnings("checkstyle:methodcount")
 public class LocalIndexStatsImpl implements LocalIndexStats {
 
     @Probe
-    private volatile long creationTime = 0;
+    private volatile long creationTime;
 
     @Probe
-    private volatile long entryCount = 0;
+    private volatile long entryCount;
 
     @Probe
-    private volatile long queryCount = 0;
+    private volatile long queryCount;
 
     @Probe
-    private volatile long hitCount = 0;
+    private volatile long hitCount;
 
     @Probe
-    private volatile long averageHitLatency = 0;
+    private volatile long averageHitLatency;
 
     @Probe
-    private volatile double averageHitSelectivity = 0.0;
+    private volatile double averageHitSelectivity;
 
     @Probe
-    private volatile long insertCount = 0;
+    private volatile long insertCount;
 
     @Probe
-    private volatile long totalInsertLatency = 0;
+    private volatile long totalInsertLatency;
 
     @Probe
-    private volatile long updateCount = 0;
+    private volatile long updateCount;
 
     @Probe
-    private volatile long totalUpdateLatency = 0;
+    private volatile long totalUpdateLatency;
 
     @Probe
-    private volatile long removeCount = 0;
+    private volatile long removeCount;
 
     @Probe
-    private volatile long totalRemoveLatency = 0;
+    private volatile long totalRemoveLatency;
 
     @Probe
-    private volatile long onHeapMemoryCost = 0;
+    private volatile long onHeapMemoryCost;
 
     @Probe
-    private volatile long offHeapMemoryCost = 0;
+    private volatile long offHeapMemoryCost;
 
     @Override
     public long getCreationTime() {

--- a/hazelcast/src/main/java/com/hazelcast/monitor/impl/LocalIndexStatsImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/monitor/impl/LocalIndexStatsImpl.java
@@ -1,0 +1,329 @@
+package com.hazelcast.monitor.impl;
+
+import com.eclipsesource.json.JsonObject;
+import com.hazelcast.internal.metrics.Probe;
+import com.hazelcast.monitor.LocalIndexStats;
+
+/**
+ * Implementation of local index stats that backs the stats exposed through the
+ * public API.
+ */
+public class LocalIndexStatsImpl implements LocalIndexStats {
+
+    @Probe
+    private volatile long creationTime = 0;
+
+    @Probe
+    private volatile long entryCount = 0;
+
+    @Probe
+    private volatile long queryCount = 0;
+
+    @Probe
+    private volatile long hitCount = 0;
+
+    @Probe
+    private volatile long averageHitLatency = 0;
+
+    @Probe
+    private volatile double averageHitSelectivity = 0.0;
+
+    @Probe
+    private volatile long insertCount = 0;
+
+    @Probe
+    private volatile long totalInsertLatency = 0;
+
+    @Probe
+    private volatile long updateCount = 0;
+
+    @Probe
+    private volatile long totalUpdateLatency = 0;
+
+    @Probe
+    private volatile long removeCount = 0;
+
+    @Probe
+    private volatile long totalRemoveLatency = 0;
+
+    @Probe
+    private volatile long onHeapMemoryCost = 0;
+
+    @Probe
+    private volatile long offHeapMemoryCost = 0;
+
+    @Override
+    public long getCreationTime() {
+        return creationTime;
+    }
+
+    /**
+     * Sets the creation of this stats to the given creation time.
+     *
+     * @param creationTime the creation time to set.
+     */
+    public void setCreationTime(long creationTime) {
+        this.creationTime = creationTime;
+    }
+
+    @Override
+    public long getEntryCount() {
+        return entryCount;
+    }
+
+    /**
+     * Sets the entry count of this stats to the given entry count.
+     *
+     * @param entryCount the entry count to set.
+     */
+    public void setEntryCount(long entryCount) {
+        this.entryCount = entryCount;
+    }
+
+    @Override
+    public long getQueryCount() {
+        return queryCount;
+    }
+
+    /**
+     * Sets the query count of this stats to the given query count.
+     *
+     * @param queryCount the query count to set.
+     */
+    public void setQueryCount(long queryCount) {
+        this.queryCount = queryCount;
+    }
+
+    @Override
+    public long getHitCount() {
+        return hitCount;
+    }
+
+    /**
+     * Sets the hit count of this stats to the given hit count.
+     *
+     * @param hitCount the hit count to set.
+     */
+    public void setHitCount(long hitCount) {
+        this.hitCount = hitCount;
+    }
+
+    @Override
+    public long getAverageHitLatency() {
+        return averageHitLatency;
+    }
+
+    /**
+     * Sets the average hit latency of this stats to the given average hit
+     * latency.
+     *
+     * @param averageHitLatency the average hit latency to set.
+     */
+    public void setAverageHitLatency(long averageHitLatency) {
+        this.averageHitLatency = averageHitLatency;
+    }
+
+    @Override
+    public double getAverageHitSelectivity() {
+        return averageHitSelectivity;
+    }
+
+    /**
+     * Sets the average hit selectivity of this stats to the given average hit
+     * selectivity.
+     *
+     * @param averageHitSelectivity the average hit selectivity to set.
+     */
+    public void setAverageHitSelectivity(double averageHitSelectivity) {
+        this.averageHitSelectivity = averageHitSelectivity;
+    }
+
+    @Override
+    public long getInsertCount() {
+        return insertCount;
+    }
+
+    /**
+     * Sets the insert count of this stats to the given insert count.
+     *
+     * @param insertCount the insert count to set.
+     */
+    public void setInsertCount(long insertCount) {
+        this.insertCount = insertCount;
+    }
+
+    @Override
+    public long getTotalInsertLatency() {
+        return totalInsertLatency;
+    }
+
+    /**
+     * Sets the total insert latency of this stats to the given total insert
+     * latency.
+     *
+     * @param totalInsertLatency the total insert latency to set.
+     */
+    public void setTotalInsertLatency(long totalInsertLatency) {
+        this.totalInsertLatency = totalInsertLatency;
+    }
+
+    @Override
+    public long getUpdateCount() {
+        return updateCount;
+    }
+
+    /**
+     * Sets the update count of this stats to the given update count.
+     *
+     * @param updateCount the update count to set.
+     */
+    public void setUpdateCount(long updateCount) {
+        this.updateCount = updateCount;
+    }
+
+    @Override
+    public long getTotalUpdateLatency() {
+        return totalUpdateLatency;
+    }
+
+    /**
+     * Sets the total update latency of this stats to the given total update
+     * latency.
+     *
+     * @param totalUpdateLatency the total update latency to set.
+     */
+    public void setTotalUpdateLatency(long totalUpdateLatency) {
+        this.totalUpdateLatency = totalUpdateLatency;
+    }
+
+    @Override
+    public long getRemoveCount() {
+        return removeCount;
+    }
+
+    /**
+     * Sets the remove count of this stats to the given remove count.
+     *
+     * @param removeCount the remove count to set.
+     */
+    public void setRemoveCount(long removeCount) {
+        this.removeCount = removeCount;
+    }
+
+    @Override
+    public long getTotalRemoveLatency() {
+        return totalRemoveLatency;
+    }
+
+    /**
+     * Sets the total remove latency of this stats to the given total remove
+     * latency.
+     *
+     * @param totalRemoveLatency the total remove latency to set.
+     */
+    public void setTotalRemoveLatency(long totalRemoveLatency) {
+        this.totalRemoveLatency = totalRemoveLatency;
+    }
+
+    @Override
+    public long getOnHeapMemoryCost() {
+        return onHeapMemoryCost;
+    }
+
+    /**
+     * Sets the on-heap memory cost of this stats to the given on-heap memory
+     * cost value.
+     *
+     * @param onHeapMemoryCost the on-heap memory cost value to set.
+     */
+    public void setOnHeapMemoryCost(long onHeapMemoryCost) {
+        this.onHeapMemoryCost = onHeapMemoryCost;
+    }
+
+    @Override
+    public long getOffHeapMemoryCost() {
+        return offHeapMemoryCost;
+    }
+
+    /**
+     * Sets the off-heap memory cost of this stats to the given off-heap memory
+     * cost value.
+     *
+     * @param offHeapMemoryCost the off-heap memory cost value to set.
+     */
+    public void setOffHeapMemoryCost(long offHeapMemoryCost) {
+        this.offHeapMemoryCost = offHeapMemoryCost;
+    }
+
+    /**
+     * Sets all the values in this stats to the corresponding values in the
+     * given on-demand stats.
+     *
+     * @param onDemandStats the on-demand stats to fetch the values to set from.
+     */
+    public void setAllFrom(OnDemandIndexStats onDemandStats) {
+        this.creationTime = onDemandStats.getCreationTime();
+        this.hitCount = onDemandStats.getHitCount();
+        this.queryCount = onDemandStats.getQueryCount();
+        this.entryCount = onDemandStats.getEntryCount();
+        this.averageHitSelectivity = onDemandStats.getAverageHitSelectivity();
+        this.averageHitLatency = onDemandStats.getAverageHitLatency();
+        this.insertCount = onDemandStats.getInsertCount();
+        this.totalInsertLatency = onDemandStats.getTotalInsertLatency();
+        this.updateCount = onDemandStats.getUpdateCount();
+        this.totalUpdateLatency = onDemandStats.getTotalUpdateLatency();
+        this.removeCount = onDemandStats.getRemoveCount();
+        this.totalRemoveLatency = onDemandStats.getTotalRemoveLatency();
+        this.onHeapMemoryCost = onDemandStats.getOnHeapMemoryCost();
+        this.offHeapMemoryCost = onDemandStats.getOffHeapMemoryCost();
+    }
+
+    @Override
+    public JsonObject toJson() {
+        JsonObject json = new JsonObject();
+        json.add("creationTime", creationTime);
+        json.add("hitCount", hitCount);
+        json.add("queryCount", queryCount);
+        json.add("entryCount", entryCount);
+        json.add("averageHitSelectivity", averageHitSelectivity);
+        json.add("averageHitLatency", averageHitLatency);
+        json.add("insertCount", insertCount);
+        json.add("totalInsertLatency", totalInsertLatency);
+        json.add("updateCount", updateCount);
+        json.add("totalUpdateLatency", totalUpdateLatency);
+        json.add("removeCount", removeCount);
+        json.add("totalRemoveLatency", totalRemoveLatency);
+        json.add("onHeapMemoryCost", onHeapMemoryCost);
+        json.add("offHeapMemoryCost", offHeapMemoryCost);
+        return json;
+    }
+
+    @Override
+    public void fromJson(JsonObject json) {
+        creationTime = json.getLong("creationTime", -1);
+        hitCount = json.getLong("hitCount", -1);
+        queryCount = json.getLong("queryCount", -1);
+        entryCount = json.getLong("entryCount", -1);
+        averageHitSelectivity = json.getDouble("averageHitSelectivity", -1.0);
+        averageHitLatency = json.getLong("averageHitLatency", -1);
+        insertCount = json.getLong("insertCount", -1);
+        totalInsertLatency = json.getLong("totalInsertLatency", -1);
+        updateCount = json.getLong("updateCount", -1);
+        totalUpdateLatency = json.getLong("totalUpdateLatency", -1);
+        removeCount = json.getLong("removeCount", -1);
+        totalRemoveLatency = json.getLong("totalRemoveLatency", -1);
+        onHeapMemoryCost = json.getLong("onHeapMemoryCost", -1);
+        offHeapMemoryCost = json.getLong("offHeapMemoryCost", -1);
+    }
+
+    @Override
+    public String toString() {
+        return "LocalIndexStatsImpl{" + "creationTime=" + creationTime + ", hitCount=" + hitCount + ", entryCount=" + entryCount
+                + ", queryCount=" + queryCount + ", averageHitSelectivity=" + averageHitSelectivity + ", averageHitLatency="
+                + averageHitLatency + ", insertCount=" + insertCount + ", totalInsertLatency=" + totalInsertLatency
+                + ", updateCount=" + updateCount + ", totalUpdateLatency=" + totalUpdateLatency + ", removeCount=" + removeCount
+                + ", totalRemoveLatency=" + totalRemoveLatency + ", onHeapMemoryCost=" + onHeapMemoryCost + ", offHeapMemoryCost="
+                + offHeapMemoryCost + '}';
+    }
+
+}

--- a/hazelcast/src/main/java/com/hazelcast/monitor/impl/LocalMapStatsImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/monitor/impl/LocalMapStatsImpl.java
@@ -17,17 +17,25 @@
 package com.hazelcast.monitor.impl;
 
 import com.eclipsesource.json.JsonObject;
+import com.eclipsesource.json.JsonObject.Member;
 import com.eclipsesource.json.JsonValue;
 import com.hazelcast.internal.metrics.Probe;
+import com.hazelcast.monitor.LocalIndexStats;
 import com.hazelcast.monitor.LocalMapStats;
 import com.hazelcast.monitor.NearCacheStats;
 import com.hazelcast.util.Clock;
 
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
 
 import static com.hazelcast.util.ConcurrencyUtil.setMax;
 import static com.hazelcast.util.JsonUtil.getInt;
 import static com.hazelcast.util.JsonUtil.getLong;
+import static com.hazelcast.util.JsonUtil.getObject;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static java.util.concurrent.TimeUnit.NANOSECONDS;
 import static java.util.concurrent.atomic.AtomicLongFieldUpdater.newUpdater;
@@ -66,6 +74,10 @@ public class LocalMapStatsImpl implements LocalMapStats {
     private static final AtomicLongFieldUpdater<LocalMapStatsImpl> MAX_REMOVE_LATENCY =
             newUpdater(LocalMapStatsImpl.class, "maxRemoveLatency");
 
+    private final ConcurrentMap<String, LocalIndexStatsImpl> mutableIndexStats = new ConcurrentHashMap<String, LocalIndexStatsImpl>();
+    private final Map<String, LocalIndexStats> indexStats = Collections.<String, LocalIndexStats>unmodifiableMap(
+            mutableIndexStats);
+
     // These fields are only accessed through the updaters
     @Probe
     private volatile long lastAccessTime;
@@ -89,7 +101,6 @@ public class LocalMapStatsImpl implements LocalMapStats {
     private volatile long maxGetLatency;
     private volatile long maxPutLatency;
     private volatile long maxRemoveLatency;
-
     @Probe
     private volatile long creationTime;
     @Probe
@@ -111,8 +122,11 @@ public class LocalMapStatsImpl implements LocalMapStats {
     private volatile long dirtyEntryCount;
     @Probe
     private volatile int backupCount;
-
     private volatile NearCacheStats nearCacheStats;
+    @Probe
+    private volatile long queryCount;
+    @Probe
+    private volatile long indexedQueryCount;
 
     public LocalMapStatsImpl() {
         creationTime = Clock.currentTimeMillis();
@@ -214,23 +228,8 @@ public class LocalMapStatsImpl implements LocalMapStats {
     }
 
     @Override
-    public long total() {
-        return putCount + getCount + removeCount + numberOfOtherOperations;
-    }
-
-    @Override
     public long getPutOperationCount() {
         return putCount;
-    }
-
-    public void incrementPutLatencyNanos(long latencyNanos) {
-        incrementPutLatencyNanos(1, latencyNanos);
-    }
-
-    public void incrementPutLatencyNanos(long delta, long latencyNanos) {
-        PUT_COUNT.addAndGet(this, delta);
-        TOTAL_PUT_LATENCIES.addAndGet(this, latencyNanos);
-        setMax(this, MAX_PUT_LATENCY, latencyNanos);
     }
 
     @Override
@@ -238,25 +237,9 @@ public class LocalMapStatsImpl implements LocalMapStats {
         return getCount;
     }
 
-    public void incrementGetLatencyNanos(long latencyNanos) {
-        incrementGetLatencyNanos(1, latencyNanos);
-    }
-
-    public void incrementGetLatencyNanos(long delta, long latencyNanos) {
-        GET_COUNT.addAndGet(this, delta);
-        TOTAL_GET_LATENCIES.addAndGet(this, latencyNanos);
-        setMax(this, MAX_GET_LATENCY, latencyNanos);
-    }
-
     @Override
     public long getRemoveOperationCount() {
         return removeCount;
-    }
-
-    public void incrementRemoveLatencyNanos(long latencyNanos) {
-        REMOVE_COUNT.incrementAndGet(this);
-        TOTAL_REMOVE_LATENCIES.addAndGet(this, latencyNanos);
-        setMax(this, MAX_REMOVE_LATENCY, latencyNanos);
     }
 
     @Probe
@@ -296,21 +279,18 @@ public class LocalMapStatsImpl implements LocalMapStats {
     }
 
     @Override
-    public long getOtherOperationCount() {
-        return numberOfOtherOperations;
-    }
-
-    public void incrementOtherOperations() {
-        NUMBER_OF_OTHER_OPERATIONS.incrementAndGet(this);
-    }
-
-    @Override
     public long getEventOperationCount() {
         return numberOfEvents;
     }
 
-    public void incrementReceivedEvents() {
-        NUMBER_OF_EVENTS.incrementAndGet(this);
+    @Override
+    public long getOtherOperationCount() {
+        return numberOfOtherOperations;
+    }
+
+    @Override
+    public long total() {
+        return putCount + getCount + removeCount + numberOfOtherOperations;
     }
 
     @Override
@@ -329,6 +309,100 @@ public class LocalMapStatsImpl implements LocalMapStats {
 
     public void setNearCacheStats(NearCacheStats nearCacheStats) {
         this.nearCacheStats = nearCacheStats;
+    }
+
+    @Override
+    public long getQueryCount() {
+        return queryCount;
+    }
+
+    /**
+     * Sets the query count of this stats to the given query count value.
+     *
+     * @param queryCount the query count value to set.
+     */
+    public void setQueryCount(long queryCount) {
+        this.queryCount = queryCount;
+    }
+
+    @Override
+    public long getIndexedQueryCount() {
+        return indexedQueryCount;
+    }
+
+    /**
+     * Sets the indexed query count of this stats to the given indexed query
+     * count value.
+     *
+     * @param indexedQueryCount the indexed query count value to set.
+     */
+    public void setIndexedQueryCount(long indexedQueryCount) {
+        this.indexedQueryCount = indexedQueryCount;
+    }
+
+    @Override
+    public Map<String, LocalIndexStats> getIndexStats() {
+        return indexStats;
+    }
+
+    /**
+     * Sets the per-index stats of this map stats to the given per-index stats.
+     *
+     * @param indexStats the per-index stats to set.
+     */
+    public void setIndexStats(Map<String, LocalIndexStatsImpl> indexStats) {
+        this.mutableIndexStats.clear();
+        if (indexStats != null) {
+            this.mutableIndexStats.putAll(indexStats);
+        }
+    }
+
+    public void incrementPutLatencyNanos(long latencyNanos) {
+        incrementPutLatencyNanos(1, latencyNanos);
+    }
+
+    public void incrementPutLatencyNanos(long delta, long latencyNanos) {
+        PUT_COUNT.addAndGet(this, delta);
+        TOTAL_PUT_LATENCIES.addAndGet(this, latencyNanos);
+        setMax(this, MAX_PUT_LATENCY, latencyNanos);
+    }
+
+    public void incrementGetLatencyNanos(long latencyNanos) {
+        incrementGetLatencyNanos(1, latencyNanos);
+    }
+
+    public void incrementGetLatencyNanos(long delta, long latencyNanos) {
+        GET_COUNT.addAndGet(this, delta);
+        TOTAL_GET_LATENCIES.addAndGet(this, latencyNanos);
+        setMax(this, MAX_GET_LATENCY, latencyNanos);
+    }
+
+    public void incrementRemoveLatencyNanos(long latencyNanos) {
+        REMOVE_COUNT.incrementAndGet(this);
+        TOTAL_REMOVE_LATENCIES.addAndGet(this, latencyNanos);
+        setMax(this, MAX_REMOVE_LATENCY, latencyNanos);
+    }
+
+    public void incrementOtherOperations() {
+        NUMBER_OF_OTHER_OPERATIONS.incrementAndGet(this);
+    }
+
+    public void incrementReceivedEvents() {
+        NUMBER_OF_EVENTS.incrementAndGet(this);
+    }
+
+    public void updateIndexStats(Map<String, OnDemandIndexStats> freshIndexStats) {
+        for (Map.Entry<String, OnDemandIndexStats> freshIndexEntry : freshIndexStats.entrySet()) {
+            String indexName = freshIndexEntry.getKey();
+            LocalIndexStatsImpl indexStats = mutableIndexStats.get(indexName);
+            if (indexStats == null) {
+                indexStats = new LocalIndexStatsImpl();
+                indexStats.setAllFrom(freshIndexEntry.getValue());
+                mutableIndexStats.putIfAbsent(indexName, indexStats);
+            } else {
+                indexStats.setAllFrom(freshIndexEntry.getValue());
+            }
+        }
     }
 
     @Override
@@ -363,6 +437,18 @@ public class LocalMapStatsImpl implements LocalMapStats {
         if (nearCacheStats != null) {
             root.add("nearCacheStats", nearCacheStats.toJson());
         }
+
+        root.add("queryCount", queryCount);
+        root.add("indexedQueryCount", indexedQueryCount);
+        Map<String, LocalIndexStats> localIndexStats = indexStats;
+        if (!localIndexStats.isEmpty()) {
+            JsonObject indexes = new JsonObject();
+            for (Map.Entry<String, LocalIndexStats> indexEntry : localIndexStats.entrySet()) {
+                indexes.add(indexEntry.getKey(), indexEntry.getValue().toJson());
+            }
+            root.add("indexStats", indexes);
+        }
+
         return root;
     }
 
@@ -399,6 +485,21 @@ public class LocalMapStatsImpl implements LocalMapStats {
             nearCacheStats = new NearCacheStatsImpl();
             nearCacheStats.fromJson(jsonNearCacheStats.asObject());
         }
+
+        queryCount = getLong(json, "queryCount", -1L);
+        indexedQueryCount = getLong(json, "indexedQueryCount", -1L);
+        JsonObject indexes = getObject(json, "indexStats", null);
+        if (indexes != null && !indexes.isEmpty()) {
+            Map<String, LocalIndexStatsImpl> localIndexStats = new HashMap<String, LocalIndexStatsImpl>();
+            for (Member member : indexes) {
+                LocalIndexStatsImpl indexStats = new LocalIndexStatsImpl();
+                indexStats.fromJson(member.getValue().asObject());
+                localIndexStats.put(member.getName(), indexStats);
+            }
+            setIndexStats(localIndexStats);
+        } else {
+            setIndexStats(null);
+        }
     }
 
     @Override
@@ -428,6 +529,9 @@ public class LocalMapStatsImpl implements LocalMapStats {
                 + ", dirtyEntryCount=" + dirtyEntryCount
                 + ", heapCost=" + heapCost
                 + ", nearCacheStats=" + (nearCacheStats != null ? nearCacheStats : "")
+                + ", queryCount=" + queryCount
+                + ", indexedQueryCount=" + indexedQueryCount
+                + ", indexStats=" + indexStats
                 + '}';
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/monitor/impl/LocalMapStatsImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/monitor/impl/LocalMapStatsImpl.java
@@ -74,7 +74,8 @@ public class LocalMapStatsImpl implements LocalMapStats {
     private static final AtomicLongFieldUpdater<LocalMapStatsImpl> MAX_REMOVE_LATENCY =
             newUpdater(LocalMapStatsImpl.class, "maxRemoveLatency");
 
-    private final ConcurrentMap<String, LocalIndexStatsImpl> mutableIndexStats = new ConcurrentHashMap<String, LocalIndexStatsImpl>();
+    private final ConcurrentMap<String, LocalIndexStatsImpl> mutableIndexStats =
+            new ConcurrentHashMap<String, LocalIndexStatsImpl>();
     private final Map<String, LocalIndexStats> indexStats = Collections.<String, LocalIndexStats>unmodifiableMap(
             mutableIndexStats);
 

--- a/hazelcast/src/main/java/com/hazelcast/monitor/impl/LocalMapStatsImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/monitor/impl/LocalMapStatsImpl.java
@@ -393,6 +393,15 @@ public class LocalMapStatsImpl implements LocalMapStats {
     }
 
     public void updateIndexStats(Map<String, OnDemandIndexStats> freshIndexStats) {
+        // A new index can be added, but already existing indexes can't be
+        // removed, that matches the current implementation properties of the
+        // index management.
+
+        if (freshIndexStats == null) {
+            // no indexes yet
+            return;
+        }
+
         for (Map.Entry<String, OnDemandIndexStats> freshIndexEntry : freshIndexStats.entrySet()) {
             String indexName = freshIndexEntry.getKey();
             LocalIndexStatsImpl indexStats = mutableIndexStats.get(indexName);

--- a/hazelcast/src/main/java/com/hazelcast/monitor/impl/LocalReplicatedMapStatsImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/monitor/impl/LocalReplicatedMapStatsImpl.java
@@ -18,9 +18,12 @@ package com.hazelcast.monitor.impl;
 
 import com.eclipsesource.json.JsonObject;
 import com.hazelcast.internal.metrics.Probe;
+import com.hazelcast.monitor.LocalIndexStats;
 import com.hazelcast.monitor.LocalReplicatedMapStats;
 import com.hazelcast.util.Clock;
 
+import java.util.Collections;
+import java.util.Map;
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
 
 import static com.hazelcast.util.ConcurrencyUtil.setMax;
@@ -307,6 +310,24 @@ public class LocalReplicatedMapStatsImpl implements LocalReplicatedMapStats {
     @Override
     public NearCacheStatsImpl getNearCacheStats() {
         throw new UnsupportedOperationException("Replicated map has no Near Cache!");
+    }
+
+    @Override
+    public long getQueryCount() {
+        // there is no query support for replicated maps
+        return 0;
+    }
+
+    @Override
+    public long getIndexedQueryCount() {
+        // there is no query support for replicated maps
+        return 0;
+    }
+
+    @Override
+    public Map<String, LocalIndexStats> getIndexStats() {
+        // there is no query support for replicated maps
+        return Collections.emptyMap();
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/monitor/impl/OnDemandIndexStats.java
+++ b/hazelcast/src/main/java/com/hazelcast/monitor/impl/OnDemandIndexStats.java
@@ -1,40 +1,57 @@
+/*
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.hazelcast.monitor.impl;
 
 /**
  * Holds the intermediate results while combining the partitioned index stats
  * to produce the final per-index stats.
  */
+@SuppressWarnings("checkstyle:methodcount")
 public class OnDemandIndexStats {
 
-    private long creationTime = 0;
+    private long creationTime;
 
-    private long entryCount = 0;
+    private long entryCount;
 
-    private long queryCount = 0;
+    private long queryCount;
 
-    private long hitCount = 0;
+    private long hitCount;
 
-    private long averageHitLatency = 0;
+    private long averageHitLatency;
 
-    private double averageHitSelectivity = 0.0;
+    private double averageHitSelectivity;
 
-    private long insertCount = 0;
+    private long insertCount;
 
-    private long totalInsertLatency = 0;
+    private long totalInsertLatency;
 
-    private long updateCount = 0;
+    private long updateCount;
 
-    private long totalUpdateLatency = 0;
+    private long totalUpdateLatency;
 
-    private long removeCount = 0;
+    private long removeCount;
 
-    private long totalRemoveLatency = 0;
+    private long totalRemoveLatency;
 
-    private long onHeapMemoryCost = 0;
+    private long onHeapMemoryCost;
 
-    private long offHeapMemoryCost = 0;
+    private long offHeapMemoryCost;
 
-    private long totalHitCount = 0;
+    private long totalHitCount;
 
     /**
      * Returns the creation time.

--- a/hazelcast/src/main/java/com/hazelcast/monitor/impl/OnDemandIndexStats.java
+++ b/hazelcast/src/main/java/com/hazelcast/monitor/impl/OnDemandIndexStats.java
@@ -1,0 +1,289 @@
+package com.hazelcast.monitor.impl;
+
+/**
+ * Holds the intermediate results while combining the partitioned index stats
+ * to produce the final per-index stats.
+ */
+public class OnDemandIndexStats {
+
+    private long creationTime = 0;
+
+    private long entryCount = 0;
+
+    private long queryCount = 0;
+
+    private long hitCount = 0;
+
+    private long averageHitLatency = 0;
+
+    private double averageHitSelectivity = 0.0;
+
+    private long insertCount = 0;
+
+    private long totalInsertLatency = 0;
+
+    private long updateCount = 0;
+
+    private long totalUpdateLatency = 0;
+
+    private long removeCount = 0;
+
+    private long totalRemoveLatency = 0;
+
+    private long onHeapMemoryCost = 0;
+
+    private long offHeapMemoryCost = 0;
+
+    private long totalHitCount = 0;
+
+    /**
+     * Returns the creation time.
+     */
+    public long getCreationTime() {
+        return creationTime;
+    }
+
+    /**
+     * Sets the creation time the given value.
+     *
+     * @param creationTime the creation time to set.
+     */
+    public void setCreationTime(long creationTime) {
+        this.creationTime = creationTime;
+    }
+
+    /**
+     * Returns the entry count.
+     */
+    public long getEntryCount() {
+        return entryCount;
+    }
+
+    /**
+     * Sets the entry count to the given value.
+     *
+     * @param entryCount the entry count value to set.
+     */
+    public void setEntryCount(long entryCount) {
+        this.entryCount = entryCount;
+    }
+
+    /**
+     * Returns the query count.
+     */
+    public long getQueryCount() {
+        return queryCount;
+    }
+
+    /**
+     * Sets the query count to the given value.
+     *
+     * @param queryCount the query count value to set.
+     */
+    public void setQueryCount(long queryCount) {
+        this.queryCount = queryCount;
+    }
+
+    /**
+     * Returns the hit count.
+     */
+    public long getHitCount() {
+        return hitCount;
+    }
+
+    /**
+     * Sets the hit count to the given value.
+     *
+     * @param hitCount the hit count value to set.
+     */
+    public void setHitCount(long hitCount) {
+        this.hitCount = hitCount;
+    }
+
+    /**
+     * Returns the average hit latency.
+     */
+    public long getAverageHitLatency() {
+        return averageHitLatency;
+    }
+
+    /**
+     * Sets the average hit latency to the given value.
+     *
+     * @param averageHitLatency the average hit latency value to set.
+     */
+    public void setAverageHitLatency(long averageHitLatency) {
+        this.averageHitLatency = averageHitLatency;
+    }
+
+    /**
+     * Returns the average hit selectivity.
+     */
+    public double getAverageHitSelectivity() {
+        return averageHitSelectivity;
+    }
+
+    /**
+     * Sets the average hit selectivity to the given value.
+     *
+     * @param averageHitSelectivity the average hit selectivity value to set.
+     */
+    public void setAverageHitSelectivity(double averageHitSelectivity) {
+        this.averageHitSelectivity = averageHitSelectivity;
+    }
+
+    /**
+     * Returns the insert count.
+     */
+    public long getInsertCount() {
+        return insertCount;
+    }
+
+    /**
+     * Sets the insert count to the given value.
+     *
+     * @param insertCount the insert count value to set.
+     */
+    public void setInsertCount(long insertCount) {
+        this.insertCount = insertCount;
+    }
+
+    /**
+     * Returns the total insert latency.
+     */
+    public long getTotalInsertLatency() {
+        return totalInsertLatency;
+    }
+
+    /**
+     * Sets the total insert latency to the given value.
+     *
+     * @param totalInsertLatency the total insert latency value to set.
+     */
+    public void setTotalInsertLatency(long totalInsertLatency) {
+        this.totalInsertLatency = totalInsertLatency;
+    }
+
+    /**
+     * Returns the update count.
+     */
+    public long getUpdateCount() {
+        return updateCount;
+    }
+
+    /**
+     * Sets the update count to the given value.
+     *
+     * @param updateCount the update count value to set.
+     */
+    public void setUpdateCount(long updateCount) {
+        this.updateCount = updateCount;
+    }
+
+    /**
+     * Returns the total update latency.
+     */
+    public long getTotalUpdateLatency() {
+        return totalUpdateLatency;
+    }
+
+    /**
+     * Sets the total update latency to the given value.
+     *
+     * @param totalUpdateLatency the total update latency value to set.
+     */
+    public void setTotalUpdateLatency(long totalUpdateLatency) {
+        this.totalUpdateLatency = totalUpdateLatency;
+    }
+
+    /**
+     * Returns the remove count.
+     */
+    public long getRemoveCount() {
+        return removeCount;
+    }
+
+    /**
+     * Sets the remove count to the given value.
+     *
+     * @param removeCount the remove count value to set.
+     */
+    public void setRemoveCount(long removeCount) {
+        this.removeCount = removeCount;
+    }
+
+    /**
+     * Returns the total remove latency.
+     */
+    public long getTotalRemoveLatency() {
+        return totalRemoveLatency;
+    }
+
+    /**
+     * Sets the total remove latency to the given value.
+     *
+     * @param totalRemoveLatency the total remove latency value to set.
+     */
+    public void setTotalRemoveLatency(long totalRemoveLatency) {
+        this.totalRemoveLatency = totalRemoveLatency;
+    }
+
+    /**
+     * Returns the on-heap memory cost.
+     */
+    public long getOnHeapMemoryCost() {
+        return onHeapMemoryCost;
+    }
+
+    /**
+     * Sets the on-heap memory cost to the given value.
+     *
+     * @param onHeapMemoryCost the on-heap memory cost value to set.
+     */
+    public void setOnHeapMemoryCost(long onHeapMemoryCost) {
+        this.onHeapMemoryCost = onHeapMemoryCost;
+    }
+
+    /**
+     * Returns the off-heap memory cost.
+     */
+    public long getOffHeapMemoryCost() {
+        return offHeapMemoryCost;
+    }
+
+    /**
+     * Sets the off-heap memory cost to the given value.
+     *
+     * @param offHeapMemoryCost the off-heap memory cost value to set.
+     */
+    public void setOffHeapMemoryCost(long offHeapMemoryCost) {
+        this.offHeapMemoryCost = offHeapMemoryCost;
+    }
+
+    /**
+     * Returns the total hit count.
+     */
+    public long getTotalHitCount() {
+        return totalHitCount;
+    }
+
+    /**
+     * Sets the total hit count to the given value.
+     *
+     * @param totalHitCount the total hit count value to set.
+     */
+    public void setTotalHitCount(long totalHitCount) {
+        this.totalHitCount = totalHitCount;
+    }
+
+    @Override
+    public String toString() {
+        return "LocalIndexStatsImpl{" + "creationTime=" + creationTime + ", hitCount=" + hitCount + ", entryCount=" + entryCount
+                + ", queryCount=" + queryCount + ", averageHitSelectivity=" + averageHitSelectivity + ", averageHitLatency="
+                + averageHitLatency + ", insertCount=" + insertCount + ", totalInsertLatency=" + totalInsertLatency
+                + ", updateCount=" + updateCount + ", totalUpdateLatency=" + totalUpdateLatency + ", removeCount=" + removeCount
+                + ", totalRemoveLatency=" + totalRemoveLatency + ", onHeapMemoryCost=" + onHeapMemoryCost + ", offHeapMemoryCost="
+                + offHeapMemoryCost + ", totalHitCount=" + totalHitCount + '}';
+    }
+
+}

--- a/hazelcast/src/main/java/com/hazelcast/monitor/impl/PartitionIndexStats.java
+++ b/hazelcast/src/main/java/com/hazelcast/monitor/impl/PartitionIndexStats.java
@@ -1,0 +1,257 @@
+package com.hazelcast.monitor.impl;
+
+import com.hazelcast.internal.memory.MemoryAllocator;
+import com.hazelcast.util.Clock;
+
+import java.util.concurrent.atomic.AtomicLongFieldUpdater;
+
+import static java.util.concurrent.atomic.AtomicLongFieldUpdater.newUpdater;
+
+/**
+ * The implementation of internal index stats specialized for partitioned indexes.
+ * <p>
+ * The main trait of the implementation is the lack of concurrency support since
+ * partitioned indexes and their stats are updated from a single thread only.
+ */
+public class PartitionIndexStats implements InternalIndexStats {
+
+    private static final AtomicLongFieldUpdater<PartitionIndexStats> ENTRY_COUNT = newUpdater(PartitionIndexStats.class,
+            "entryCount");
+    private static final AtomicLongFieldUpdater<PartitionIndexStats> QUERY_COUNT = newUpdater(PartitionIndexStats.class,
+            "queryCount");
+    private static final AtomicLongFieldUpdater<PartitionIndexStats> HIT_COUNT = newUpdater(PartitionIndexStats.class,
+            "hitCount");
+    private static final AtomicLongFieldUpdater<PartitionIndexStats> TOTAL_HIT_LATENCY = newUpdater(PartitionIndexStats.class,
+            "totalHitLatency");
+    private static final AtomicLongFieldUpdater<PartitionIndexStats> TOTAL_NORMALIZED_HIT_CARDINALITY = newUpdater(
+            PartitionIndexStats.class, "totalNormalizedHitCardinality");
+    private static final AtomicLongFieldUpdater<PartitionIndexStats> INSERT_COUNT = newUpdater(PartitionIndexStats.class,
+            "insertCount");
+    private static final AtomicLongFieldUpdater<PartitionIndexStats> TOTAL_INSERT_LATENCY = newUpdater(PartitionIndexStats.class,
+            "totalInsertLatency");
+    private static final AtomicLongFieldUpdater<PartitionIndexStats> UPDATE_COUNT = newUpdater(PartitionIndexStats.class,
+            "updateCount");
+    private static final AtomicLongFieldUpdater<PartitionIndexStats> TOTAL_UPDATE_LATENCY = newUpdater(PartitionIndexStats.class,
+            "totalUpdateLatency");
+    private static final AtomicLongFieldUpdater<PartitionIndexStats> REMOVE_COUNT = newUpdater(PartitionIndexStats.class,
+            "removeCount");
+    private static final AtomicLongFieldUpdater<PartitionIndexStats> TOTAL_REMOVE_LATENCY = newUpdater(PartitionIndexStats.class,
+            "totalRemoveLatency");
+    private static final AtomicLongFieldUpdater<PartitionIndexStats> MEMORY_COST = newUpdater(PartitionIndexStats.class,
+            "memoryCost");
+
+    private final long creationTime;
+
+    private volatile long entryCount = 0;
+    private volatile long queryCount = 0;
+    private volatile long hitCount = 0;
+    private volatile long totalHitLatency = 0;
+    private volatile long totalNormalizedHitCardinality = Double.doubleToRawLongBits(0.0);
+    private volatile long insertCount = 0;
+    private volatile long totalInsertLatency = 0;
+    private volatile long updateCount = 0;
+    private volatile long totalUpdateLatency = 0;
+    private volatile long removeCount = 0;
+    private volatile long totalRemoveLatency = 0;
+    private volatile long memoryCost = 0;
+
+    private boolean hasQueries;
+
+    public PartitionIndexStats() {
+        this.creationTime = Clock.currentTimeMillis();
+    }
+
+    private void updateMemoryCost(long delta) {
+        MEMORY_COST.lazySet(this, memoryCost + delta);
+    }
+
+    private void resetMemoryCost() {
+        MEMORY_COST.lazySet(PartitionIndexStats.this, 0);
+    }
+
+    @Override
+    public long makeTimestamp() {
+        return System.nanoTime();
+    }
+
+    @Override
+    public long getCreationTime() {
+        return creationTime;
+    }
+
+    @Override
+    public long getEntryCount() {
+        return entryCount;
+    }
+
+    @Override
+    public long getQueryCount() {
+        return queryCount;
+    }
+
+    @Override
+    public void incrementQueryCount() {
+        if (hasQueries) {
+            QUERY_COUNT.lazySet(this, queryCount + 1);
+        }
+    }
+
+    @Override
+    public long getHitCount() {
+        return hitCount;
+    }
+
+    @Override
+    public long getTotalHitLatency() {
+        return totalHitLatency;
+    }
+
+    @Override
+    public double getTotalNormalizedHitCardinality() {
+        return Double.longBitsToDouble(totalNormalizedHitCardinality);
+    }
+
+    @Override
+    public long getInsertCount() {
+        return insertCount;
+    }
+
+    @Override
+    public long getTotalInsertLatency() {
+        return totalInsertLatency;
+    }
+
+    @Override
+    public long getUpdateCount() {
+        return updateCount;
+    }
+
+    @Override
+    public long getTotalUpdateLatency() {
+        return totalUpdateLatency;
+    }
+
+    @Override
+    public long getRemoveCount() {
+        return removeCount;
+    }
+
+    @Override
+    public long getTotalRemoveLatency() {
+        return totalRemoveLatency;
+    }
+
+    @Override
+    public long getOnHeapMemoryCost() {
+        return 0;
+    }
+
+    @Override
+    public long getOffHeapMemoryCost() {
+        return memoryCost;
+    }
+
+    @Override
+    public void onEntryInserted(long timestamp, Object value) {
+        TOTAL_INSERT_LATENCY.lazySet(this, totalInsertLatency + (System.nanoTime() - timestamp));
+        INSERT_COUNT.lazySet(this, insertCount + 1);
+        ENTRY_COUNT.lazySet(this, entryCount + 1);
+    }
+
+    @Override
+    public void onEntryUpdated(long timestamp, Object oldValue, Object newValue) {
+        TOTAL_UPDATE_LATENCY.lazySet(this, totalUpdateLatency + (System.nanoTime() - timestamp));
+        UPDATE_COUNT.lazySet(this, updateCount + 1);
+    }
+
+    @Override
+    public void onEntryRemoved(long timestamp, Object value) {
+        TOTAL_REMOVE_LATENCY.lazySet(this, totalRemoveLatency + (System.nanoTime() - timestamp));
+        REMOVE_COUNT.lazySet(this, removeCount + 1);
+        ENTRY_COUNT.lazySet(this, entryCount - 1);
+    }
+
+    @Override
+    public void onEntriesCleared() {
+        ENTRY_COUNT.lazySet(this, 0);
+    }
+
+    @Override
+    public void onIndexHit(long timestamp, long hitCardinality) {
+        // To compute the average hit cardinality we need to track the total
+        // cardinality of all of the hits and then divide it by the number of hits.
+        // But since the number of the indexed entries may change with time, this
+        // raw total cardinality value can't provide any useful information. So
+        // instead we store the total normalized cardinality, which sums up the
+        // individual hit cardinalities divided by the index size at the time of the
+        // hit.
+
+        hasQueries = true;
+
+        long localEntryCount = entryCount;
+        if (localEntryCount == 0) {
+            // selecting nothing from nothing is not counted as a hit
+            return;
+        }
+
+        TOTAL_HIT_LATENCY.lazySet(this, totalHitLatency + (System.nanoTime() - timestamp));
+        HIT_COUNT.lazySet(this, hitCount + 1);
+
+        // limit the cardinality for "safety"
+        long adjustedHitCardinality = Math.min(hitCardinality, localEntryCount);
+
+        // this will produce a value in [0.0, 1.0] range
+        double normalizedHitCardinality = (double) adjustedHitCardinality / localEntryCount;
+
+        double decodedTotalNormalizedHitCardinality = Double.longBitsToDouble(totalNormalizedHitCardinality);
+        double newTotalNormalizedHitCardinality = decodedTotalNormalizedHitCardinality + normalizedHitCardinality;
+        long newEncodedTotalNormalizedHitCardinality = Double.doubleToRawLongBits(newTotalNormalizedHitCardinality);
+        TOTAL_NORMALIZED_HIT_CARDINALITY.lazySet(this, newEncodedTotalNormalizedHitCardinality);
+    }
+
+    @Override
+    public void resetPerQueryStats() {
+        hasQueries = false;
+    }
+
+    @Override
+    public MemoryAllocator wrapMemoryAllocator(MemoryAllocator memoryAllocator) {
+        return new MemoryAllocatorWithStats(memoryAllocator);
+    }
+
+    private class MemoryAllocatorWithStats implements MemoryAllocator {
+
+        private final MemoryAllocator delegate;
+
+        public MemoryAllocatorWithStats(MemoryAllocator delegate) {
+            this.delegate = delegate;
+        }
+
+        @Override
+        public long allocate(long size) {
+            long result = delegate.allocate(size);
+            updateMemoryCost(size);
+            return result;
+        }
+
+        @Override
+        public long reallocate(long address, long currentSize, long newSize) {
+            long result = delegate.reallocate(address, currentSize, newSize);
+            updateMemoryCost(newSize - currentSize);
+            return result;
+        }
+
+        @Override
+        public void free(long address, long size) {
+            delegate.free(address, size);
+            updateMemoryCost(-size);
+        }
+
+        @Override
+        public void dispose() {
+            delegate.dispose();
+            resetMemoryCost();
+        }
+    }
+
+}

--- a/hazelcast/src/main/java/com/hazelcast/monitor/impl/PartitionIndexStats.java
+++ b/hazelcast/src/main/java/com/hazelcast/monitor/impl/PartitionIndexStats.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.hazelcast.monitor.impl;
 
 import com.hazelcast.internal.memory.MemoryAllocator;
@@ -42,18 +58,18 @@ public class PartitionIndexStats implements InternalIndexStats {
 
     private final long creationTime;
 
-    private volatile long entryCount = 0;
-    private volatile long queryCount = 0;
-    private volatile long hitCount = 0;
-    private volatile long totalHitLatency = 0;
+    private volatile long entryCount;
+    private volatile long queryCount;
+    private volatile long hitCount;
+    private volatile long totalHitLatency;
     private volatile long totalNormalizedHitCardinality = Double.doubleToRawLongBits(0.0);
-    private volatile long insertCount = 0;
-    private volatile long totalInsertLatency = 0;
-    private volatile long updateCount = 0;
-    private volatile long totalUpdateLatency = 0;
-    private volatile long removeCount = 0;
-    private volatile long totalRemoveLatency = 0;
-    private volatile long memoryCost = 0;
+    private volatile long insertCount;
+    private volatile long totalInsertLatency;
+    private volatile long updateCount;
+    private volatile long totalUpdateLatency;
+    private volatile long removeCount;
+    private volatile long totalRemoveLatency;
+    private volatile long memoryCost;
 
     private boolean hasQueries;
 

--- a/hazelcast/src/main/java/com/hazelcast/monitor/impl/PartitionIndexesStats.java
+++ b/hazelcast/src/main/java/com/hazelcast/monitor/impl/PartitionIndexesStats.java
@@ -1,0 +1,49 @@
+package com.hazelcast.monitor.impl;
+
+import java.util.concurrent.atomic.AtomicLongFieldUpdater;
+
+import static java.util.concurrent.atomic.AtomicLongFieldUpdater.newUpdater;
+
+/**
+ * The implementation of internal indexes stats specialized for partitioned
+ * indexes.
+ * <p>
+ * The main trait of the implementation is the lack of concurrency support since
+ * partitioned indexes and their stats are updated from a single thread only.
+ */
+public class PartitionIndexesStats implements InternalIndexesStats {
+
+    private static final AtomicLongFieldUpdater<PartitionIndexesStats> QUERY_COUNT = newUpdater(PartitionIndexesStats.class,
+            "queryCount");
+    private static final AtomicLongFieldUpdater<PartitionIndexesStats> INDEXED_QUERY_COUNT = newUpdater(
+            PartitionIndexesStats.class, "indexedQueryCount");
+
+    private volatile long queryCount = 0;
+    private volatile long indexedQueryCount = 0;
+
+    @Override
+    public long getQueryCount() {
+        return queryCount;
+    }
+
+    @Override
+    public void incrementQueryCount() {
+        QUERY_COUNT.lazySet(this, queryCount + 1);
+    }
+
+    @Override
+    public long getIndexedQueryCount() {
+        return indexedQueryCount;
+    }
+
+    @Override
+    public void incrementIndexedQueryCount() {
+        INDEXED_QUERY_COUNT.lazySet(this, indexedQueryCount + 1);
+    }
+
+    @Override
+    public InternalIndexStats createIndexStats(boolean ordered, boolean queryableEntriesAreCached) {
+        return new PartitionIndexStats();
+    }
+
+}

--- a/hazelcast/src/main/java/com/hazelcast/monitor/impl/PartitionIndexesStats.java
+++ b/hazelcast/src/main/java/com/hazelcast/monitor/impl/PartitionIndexesStats.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.hazelcast.monitor.impl;
 
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
@@ -18,8 +34,8 @@ public class PartitionIndexesStats implements InternalIndexesStats {
     private static final AtomicLongFieldUpdater<PartitionIndexesStats> INDEXED_QUERY_COUNT = newUpdater(
             PartitionIndexesStats.class, "indexedQueryCount");
 
-    private volatile long queryCount = 0;
-    private volatile long indexedQueryCount = 0;
+    private volatile long queryCount;
+    private volatile long indexedQueryCount;
 
     @Override
     public long getQueryCount() {

--- a/hazelcast/src/main/java/com/hazelcast/query/IndexAwarePredicate.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/IndexAwarePredicate.java
@@ -58,7 +58,9 @@ public interface IndexAwarePredicate<K, V> extends Predicate<K, V> {
      * The query engine assumes this method produces the result set faster than
      * a simple evaluation of the predicate on every entry.
      *
-     * @param queryContext the query context to access the indexes.
+     * @param queryContext the query context to access the indexes. The passed
+     *                     query context is valid only for a duration of a single
+     *                     call to the method.
      * @return the produced filtered entry set.
      */
     Set<QueryableEntry<K, V>> filter(QueryContext queryContext);

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/GlobalQueryContextProvider.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/GlobalQueryContextProvider.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.hazelcast.query.impl;
 
 /**

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/GlobalQueryContextProvider.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/GlobalQueryContextProvider.java
@@ -1,0 +1,22 @@
+package com.hazelcast.query.impl;
+
+/**
+ * Provides the query context support for global indexes with disabled stats.
+ */
+public class GlobalQueryContextProvider implements QueryContextProvider {
+
+    private static final ThreadLocal<QueryContext> QUERY_CONTEXT = new ThreadLocal<QueryContext>() {
+        @Override
+        protected QueryContext initialValue() {
+            return new QueryContext();
+        }
+    };
+
+    @Override
+    public QueryContext obtainContextFor(Indexes indexes) {
+        QueryContext queryContext = QUERY_CONTEXT.get();
+        queryContext.attachTo(indexes);
+        return queryContext;
+    }
+
+}

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/GlobalQueryContextProviderWithStats.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/GlobalQueryContextProviderWithStats.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.hazelcast.query.impl;
 
 /**

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/GlobalQueryContextProviderWithStats.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/GlobalQueryContextProviderWithStats.java
@@ -1,0 +1,22 @@
+package com.hazelcast.query.impl;
+
+/**
+ * Provides the query context support for global indexes with enabled stats.
+ */
+public class GlobalQueryContextProviderWithStats implements QueryContextProvider {
+
+    private static final ThreadLocal<GlobalQueryContextWithStats> QUERY_CONTEXT = new ThreadLocal<GlobalQueryContextWithStats>() {
+        @Override
+        protected GlobalQueryContextWithStats initialValue() {
+            return new GlobalQueryContextWithStats();
+        }
+    };
+
+    @Override
+    public QueryContext obtainContextFor(Indexes indexes) {
+        GlobalQueryContextWithStats queryContext = QUERY_CONTEXT.get();
+        queryContext.attachTo(indexes);
+        return queryContext;
+    }
+
+}

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/GlobalQueryContextWithStats.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/GlobalQueryContextWithStats.java
@@ -1,0 +1,150 @@
+package com.hazelcast.query.impl;
+
+import com.hazelcast.core.TypeConverter;
+import com.hazelcast.monitor.impl.InternalIndexStats;
+import com.hazelcast.nio.serialization.Data;
+
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Set;
+
+/**
+ * Extends the basic query context to support the per-index stats tracking on
+ * behalf of global indexes.
+ */
+public class GlobalQueryContextWithStats extends QueryContext {
+
+    private final HashMap<String, QueryTrackingIndex> knownIndexes = new HashMap<String, QueryTrackingIndex>();
+
+    private final HashSet<QueryTrackingIndex> trackedIndexes = new HashSet<QueryTrackingIndex>(8);
+
+    @Override
+    void attachTo(Indexes indexes) {
+        super.attachTo(indexes);
+        for (QueryTrackingIndex trackedIndex : trackedIndexes) {
+            trackedIndex.resetPerQueryStats();
+        }
+        trackedIndexes.clear();
+    }
+
+    @Override
+    public Index getIndex(String attributeName) {
+        if (indexes == null) {
+            return null;
+        }
+
+        InternalIndex delegate = indexes.getIndex(attributeName);
+        if (delegate == null) {
+            return null;
+        }
+
+        QueryTrackingIndex trackingIndex = knownIndexes.get(attributeName);
+        if (trackingIndex == null) {
+            trackingIndex = new QueryTrackingIndex();
+            knownIndexes.put(attributeName, trackingIndex);
+        }
+
+        trackingIndex.attachTo(delegate);
+        trackedIndexes.add(trackingIndex);
+
+        return trackingIndex;
+    }
+
+    @Override
+    void applyPerQueryStats() {
+        for (QueryTrackingIndex trackedIndex : trackedIndexes) {
+            trackedIndex.incrementQueryCount();
+        }
+    }
+
+    private static class QueryTrackingIndex implements InternalIndex {
+
+        private InternalIndex delegate;
+
+        private boolean hasQueries;
+
+        public void attachTo(InternalIndex delegate) {
+            this.delegate = delegate;
+        }
+
+        public void resetPerQueryStats() {
+            hasQueries = false;
+        }
+
+        public void incrementQueryCount() {
+            if (hasQueries) {
+                delegate.getIndexStats().incrementQueryCount();
+            }
+        }
+
+        @Override
+        public String getAttributeName() {
+            return delegate.getAttributeName();
+        }
+
+        @Override
+        public boolean isOrdered() {
+            return delegate.isOrdered();
+        }
+
+        @Override
+        public void saveEntryIndex(QueryableEntry entry, Object oldValue) {
+            delegate.saveEntryIndex(entry, oldValue);
+        }
+
+        @Override
+        public void removeEntryIndex(Data key, Object value) {
+            delegate.removeEntryIndex(key, value);
+        }
+
+        @Override
+        public TypeConverter getConverter() {
+            return delegate.getConverter();
+        }
+
+        @Override
+        public Set<QueryableEntry> getRecords(Comparable value) {
+            Set<QueryableEntry> result = delegate.getRecords(value);
+            hasQueries = true;
+            return result;
+        }
+
+        @Override
+        public Set<QueryableEntry> getRecords(Comparable[] values) {
+            Set<QueryableEntry> result = delegate.getRecords(values);
+            hasQueries = true;
+            return result;
+        }
+
+        @Override
+        public Set<QueryableEntry> getSubRecordsBetween(Comparable from, Comparable to) {
+            Set<QueryableEntry> result = delegate.getSubRecordsBetween(from, to);
+            hasQueries = true;
+            return result;
+        }
+
+        @Override
+        public Set<QueryableEntry> getSubRecords(ComparisonType comparisonType, Comparable searchedValue) {
+            Set<QueryableEntry> result = delegate.getSubRecords(comparisonType, searchedValue);
+            hasQueries = true;
+            return result;
+        }
+
+        @Override
+        public void clear() {
+            delegate.clear();
+        }
+
+        @Override
+        public void destroy() {
+            delegate.destroy();
+        }
+
+        @Override
+        public InternalIndexStats getIndexStats() {
+            return delegate.getIndexStats();
+        }
+
+    }
+
+}

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/GlobalQueryContextWithStats.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/GlobalQueryContextWithStats.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.hazelcast.query.impl;
 
 import com.hazelcast.core.TypeConverter;

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/IndexHeapMemoryCostUtil.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/IndexHeapMemoryCostUtil.java
@@ -1,0 +1,135 @@
+package com.hazelcast.query.impl;
+
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.sql.Timestamp;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+
+/**
+ * Provides utilities useful for on-heap memory cost estimation.
+ */
+public class IndexHeapMemoryCostUtil {
+
+    // The costs below are obtained using JOL (Java Object Layout tool), they
+    // include the cost of the padding induced by 8-byte alignment of objects
+    // on the heap. Compressed pointers are assumed to be on.
+
+    private static final int BASE_ARRAY_COST = 16;
+    private static final int BASE_STRING_COST = 24 + BASE_ARRAY_COST;
+    private static final int BASE_BIG_INTEGER_COST = 40 + BASE_ARRAY_COST;
+    private static final int BASE_BIG_DECIMAL_COST = 40;
+    private static final int BASE_CONCURRENT_HASH_MAP_COST = 64 + BASE_ARRAY_COST;
+    private static final int BASE_CONCURRENT_SKIP_LIST_MAP_COST = 48;
+
+    private static final int DATE_COST = 24;
+    private static final int SQL_TIMESTAMP_COST = 32;
+    private static final int CONCURRENT_HASH_MAP_ENTRY_COST = 32;
+    private static final int CONCURRENT_SKIP_LIST_MAP_ENTRY_COST = 24;
+    private static final int QUERY_ENTRY_COST = 32;
+    private static final int CACHED_QUERYABLE_ENTRY_COST = 40;
+
+    private static final Map<Class, Integer> KNOWN_FINAL_CLASSES_COSTS;
+
+    static {
+        KNOWN_FINAL_CLASSES_COSTS = new HashMap<Class, Integer>();
+        KNOWN_FINAL_CLASSES_COSTS.put(Boolean.class, 16);
+        KNOWN_FINAL_CLASSES_COSTS.put(Character.class, 16);
+        KNOWN_FINAL_CLASSES_COSTS.put(Byte.class, 16);
+        KNOWN_FINAL_CLASSES_COSTS.put(Short.class, 16);
+        KNOWN_FINAL_CLASSES_COSTS.put(Integer.class, 16);
+        KNOWN_FINAL_CLASSES_COSTS.put(Long.class, 24);
+        KNOWN_FINAL_CLASSES_COSTS.put(Float.class, 16);
+        KNOWN_FINAL_CLASSES_COSTS.put(Double.class, 24);
+        KNOWN_FINAL_CLASSES_COSTS.put(UUID.class, 32);
+    }
+
+    // The costs below are very rough estimates, more precise answers require
+    // expensive computations which we can't afford here.
+
+    private static final int ROUGH_BIG_INTEGER_COST = BASE_BIG_INTEGER_COST + 16;
+    private static final int ROUGH_BIG_DECIMAL_COST = BASE_BIG_DECIMAL_COST + ROUGH_BIG_INTEGER_COST;
+    private static final int ROUGH_UNKNOWN_CLASS_COST = 24;
+
+    /**
+     * Estimates the on-heap of the given value.
+     *
+     * @param value the value to estimate the cost of.
+     * @return the estimated value cost.
+     */
+    public static long estimateValueCost(Object value) {
+        if (value == null) {
+            return 0;
+        }
+        Class<?> class_ = value.getClass();
+
+        Integer cost = KNOWN_FINAL_CLASSES_COSTS.get(class_);
+        if (cost != null) {
+            return cost;
+        }
+
+        if (value instanceof String) {
+            return BASE_STRING_COST + ((String) value).length() * 2L;
+        }
+
+        if (value instanceof Timestamp) {
+            return SQL_TIMESTAMP_COST;
+        }
+
+        if (value instanceof Date) {
+            return DATE_COST;
+        }
+
+        if (class_.isEnum()) {
+            // enum values are shared, so they don't cost anything
+            return 0;
+        }
+
+        if (value instanceof BigDecimal) {
+            return ROUGH_BIG_DECIMAL_COST;
+        }
+
+        if (value instanceof BigInteger) {
+            return ROUGH_BIG_INTEGER_COST;
+        }
+
+        return ROUGH_UNKNOWN_CLASS_COST;
+    }
+
+    /**
+     * Estimates the on-heap memory cost of a map backing an index.
+     *
+     * @param size                      the size of the map to estimate the cost
+     *                                  of.
+     * @param ordered                   {@code true} if the index managing the
+     *                                  map being estimated is ordered, {@code
+     *                                  false} otherwise.
+     * @param queryableEntriesAreCached {@code true} if queryable entries indexed
+     *                                  by the associated index are cached, {@code
+     *                                  false} otherwise.
+     * @return the estimated map cost.
+     */
+    public static long estimateMapCost(long size, boolean ordered, boolean queryableEntriesAreCached) {
+        long mapCost;
+        if (ordered) {
+            mapCost = BASE_CONCURRENT_SKIP_LIST_MAP_COST + size * CONCURRENT_SKIP_LIST_MAP_ENTRY_COST;
+        } else {
+            mapCost = BASE_CONCURRENT_HASH_MAP_COST + size * CONCURRENT_HASH_MAP_ENTRY_COST;
+        }
+
+        long queryableEntriesCost;
+        if (queryableEntriesAreCached) {
+            queryableEntriesCost = size * CACHED_QUERYABLE_ENTRY_COST;
+        } else {
+            queryableEntriesCost = size * QUERY_ENTRY_COST;
+        }
+
+        return mapCost + queryableEntriesCost;
+    }
+
+    private IndexHeapMemoryCostUtil() {
+    }
+
+}

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/IndexHeapMemoryCostUtil.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/IndexHeapMemoryCostUtil.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.hazelcast.query.impl;
 
 import java.math.BigDecimal;
@@ -11,7 +27,8 @@ import java.util.UUID;
 /**
  * Provides utilities useful for on-heap memory cost estimation.
  */
-public class IndexHeapMemoryCostUtil {
+@SuppressWarnings("checkstyle:magicnumber")
+public final class IndexHeapMemoryCostUtil {
 
     // The costs below are obtained using JOL (Java Object Layout tool), they
     // include the cost of the padding induced by 8-byte alignment of objects
@@ -53,19 +70,23 @@ public class IndexHeapMemoryCostUtil {
     private static final int ROUGH_BIG_DECIMAL_COST = BASE_BIG_DECIMAL_COST + ROUGH_BIG_INTEGER_COST;
     private static final int ROUGH_UNKNOWN_CLASS_COST = 24;
 
+    private IndexHeapMemoryCostUtil() {
+    }
+
     /**
      * Estimates the on-heap of the given value.
      *
      * @param value the value to estimate the cost of.
      * @return the estimated value cost.
      */
+    @SuppressWarnings({"checkstyle:npathcomplexity", "checkstyle:returncount"})
     public static long estimateValueCost(Object value) {
         if (value == null) {
             return 0;
         }
-        Class<?> class_ = value.getClass();
+        Class<?> clazz = value.getClass();
 
-        Integer cost = KNOWN_FINAL_CLASSES_COSTS.get(class_);
+        Integer cost = KNOWN_FINAL_CLASSES_COSTS.get(clazz);
         if (cost != null) {
             return cost;
         }
@@ -82,7 +103,7 @@ public class IndexHeapMemoryCostUtil {
             return DATE_COST;
         }
 
-        if (class_.isEnum()) {
+        if (clazz.isEnum()) {
             // enum values are shared, so they don't cost anything
             return 0;
         }
@@ -127,9 +148,6 @@ public class IndexHeapMemoryCostUtil {
         }
 
         return mapCost + queryableEntriesCost;
-    }
-
-    private IndexHeapMemoryCostUtil() {
     }
 
 }

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/IndexImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/IndexImpl.java
@@ -44,7 +44,7 @@ public class IndexImpl implements InternalIndex {
     private final boolean ordered;
     private final Extractors extractors;
     private final IndexCopyBehavior copyBehavior;
-    protected final InternalIndexStats stats;
+    private final InternalIndexStats stats;
 
     private volatile TypeConverter converter;
 

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/Indexes.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/Indexes.java
@@ -41,7 +41,8 @@ import java.util.concurrent.atomic.AtomicReference;
 /**
  * Contains all indexes for a data-structure, e.g. an IMap.
  */
-public final class Indexes {
+@SuppressWarnings("checkstyle:finalclass")
+public class Indexes {
     private static final InternalIndex[] EMPTY_INDEX = {};
 
     private final InternalSerializationService serializationService;

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/Indexes.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/Indexes.java
@@ -16,13 +16,22 @@
 
 package com.hazelcast.query.impl;
 
+import com.hazelcast.config.CacheDeserializedValues;
+import com.hazelcast.config.MapConfig;
 import com.hazelcast.internal.serialization.InternalSerializationService;
+import com.hazelcast.map.impl.MapContainer;
+import com.hazelcast.map.impl.MapServiceContext;
+import com.hazelcast.map.impl.query.DefaultIndexProvider;
 import com.hazelcast.map.impl.query.IndexProvider;
+import com.hazelcast.monitor.impl.GlobalIndexesStats;
+import com.hazelcast.monitor.impl.InternalIndexesStats;
+import com.hazelcast.monitor.impl.PartitionIndexesStats;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.query.IndexAwarePredicate;
 import com.hazelcast.query.Predicate;
 import com.hazelcast.query.QueryException;
 import com.hazelcast.query.impl.getters.Extractors;
+import com.hazelcast.spi.NodeEngine;
 
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
@@ -33,53 +42,120 @@ import java.util.concurrent.atomic.AtomicReference;
  * Contains all indexes for a data-structure, e.g. an IMap.
  */
 public class Indexes {
-    private static final Index[] EMPTY_INDEX = {};
-    private final ConcurrentMap<String, Index> mapIndexes = new ConcurrentHashMap<String, Index>(3);
-    private final AtomicReference<Index[]> indexes = new AtomicReference<Index[]>(EMPTY_INDEX);
-    private final IndexCopyBehavior copyBehavior;
-    private volatile boolean hasIndex;
+    private static final InternalIndex[] EMPTY_INDEX = {};
+
     private final InternalSerializationService serializationService;
     private final IndexProvider indexProvider;
     private final Extractors extractors;
     private final boolean global;
+    private final IndexCopyBehavior copyBehavior;
+    private final boolean queryableEntriesAreCached;
+    private final QueryContextProvider queryContextProvider;
+    private final InternalIndexesStats stats;
 
+    private final ConcurrentMap<String, InternalIndex> mapIndexes = new ConcurrentHashMap<String, InternalIndex>(3);
+    private final AtomicReference<InternalIndex[]> indexes = new AtomicReference<InternalIndex[]>(EMPTY_INDEX);
 
-    public Indexes(InternalSerializationService serializationService, IndexProvider indexProvider,
-                   Extractors extractors, boolean global, IndexCopyBehavior copyBehavior) {
-        this.serializationService = serializationService;
-        this.indexProvider = indexProvider;
-        this.extractors = extractors;
+    private volatile boolean hasIndex;
+
+    /**
+     * Creates a new indexes instance for use as a global indexes for the given
+     * map container.
+     *
+     * @param mapContainer the container of the map.
+     * @return the constructed indexes.
+     */
+    public static Indexes createGlobalIndexes(MapContainer mapContainer) {
+        return new Indexes(mapContainer, true);
+    }
+
+    /**
+     * Creates a new indexes instance for use as a partition indexes for the
+     * given map container.
+     *
+     * @param mapContainer the container of the map.
+     * @return the constructed indexes.
+     */
+    public static Indexes createPartitionIndexes(MapContainer mapContainer) {
+        return new Indexes(mapContainer, false);
+    }
+
+    /**
+     * Creates a new stand-alone (not attached to any map container) indexes
+     * instance for the given serialization service and with the given index
+     * copy behaviour.
+     *
+     * @param serializationService the serialization service to be used by the
+     *                             new indexes.
+     * @param copyBehavior         the desired copy behaviour of the new indexes.
+     * @return the constructed indexes.
+     */
+    public static Indexes createStandaloneIndexes(InternalSerializationService serializationService,
+                                                  IndexCopyBehavior copyBehavior) {
+        return new Indexes(serializationService, copyBehavior);
+    }
+
+    private Indexes(MapContainer mapContainer, boolean global) {
+        MapServiceContext mapServiceContext = mapContainer.getMapServiceContext();
+        MapConfig mapConfig = mapContainer.getMapConfig();
+        NodeEngine nodeEngine = mapServiceContext.getNodeEngine();
+
+        this.serializationService = (InternalSerializationService) nodeEngine.getSerializationService();
+        this.indexProvider = mapServiceContext.getIndexProvider(mapConfig);
+        this.extractors = mapContainer.getExtractors();
         this.global = global;
+        this.copyBehavior = mapServiceContext.getIndexCopyBehavior();
+        this.queryableEntriesAreCached = mapConfig.getCacheDeserializedValues() != CacheDeserializedValues.NEVER;
+        this.queryContextProvider = createQueryContextProvider(mapConfig, global);
+        this.stats = createStats(mapConfig, global);
+    }
+
+    private Indexes(InternalSerializationService serializationService, IndexCopyBehavior copyBehavior) {
+        this.serializationService = serializationService;
+        this.indexProvider = new DefaultIndexProvider();
+        this.extractors = Extractors.empty();
+        this.global = true;
         this.copyBehavior = copyBehavior;
+        this.queryableEntriesAreCached = false;
+        this.queryContextProvider = new GlobalQueryContextProvider();
+        this.stats = InternalIndexesStats.EMPTY;
     }
 
-    public synchronized Index destroyIndex(String attribute) {
-        return mapIndexes.remove(attribute);
-    }
-
-    public synchronized Index addOrGetIndex(String attribute, boolean ordered) {
-        Index index = mapIndexes.get(attribute);
+    /**
+     * Obtains the existing index or creates a new one (if an index doesn't exist
+     * yet) for the given attribute in this indexes instance.
+     *
+     * @param attribute the attribute to index.
+     * @param ordered   {@code true} if the new index should be ordered, {@code
+     *                  false} otherwise.
+     * @return the existing or created index.
+     */
+    public synchronized InternalIndex addOrGetIndex(String attribute, boolean ordered) {
+        InternalIndex index = mapIndexes.get(attribute);
         if (index != null) {
             return index;
         }
-        index = indexProvider.createIndex(attribute, ordered, extractors, serializationService, copyBehavior);
+
+        index = indexProvider.createIndex(attribute, ordered, extractors, serializationService, copyBehavior,
+                stats.createIndexStats(ordered, queryableEntriesAreCached));
         mapIndexes.put(attribute, index);
-        Object[] indexObjects = mapIndexes.values().toArray();
-        Index[] newIndexes = new Index[indexObjects.length];
-        for (int i = 0; i < indexObjects.length; i++) {
-            newIndexes[i] = (Index) indexObjects[i];
-        }
-        indexes.set(newIndexes);
+        indexes.set(mapIndexes.values().toArray(EMPTY_INDEX));
         hasIndex = true;
         return index;
     }
 
-    public Index[] getIndexes() {
+    /**
+     * Returns all the indexes known to this indexes instance.
+     */
+    public InternalIndex[] getIndexes() {
         return indexes.get();
     }
 
+    /**
+     * Destroys and then removes all the indexes from this indexes instance.
+     */
     public void clearIndexes() {
-        for (Index index : getIndexes()) {
+        for (InternalIndex index : getIndexes()) {
             index.destroy();
         }
 
@@ -92,26 +168,45 @@ public class Indexes {
      * Clears contents of indexes managed by this instance.
      */
     public void clearContents() {
-        for (Index index : getIndexes()) {
+        for (InternalIndex index : getIndexes()) {
             index.clear();
         }
     }
 
-    public void removeEntryIndex(Data key, Object value) throws QueryException {
-        Index[] indexes = getIndexes();
-        for (Index index : indexes) {
-            index.removeEntryIndex(key, value);
-        }
-    }
-
+    /**
+     * Returns {@code true} if this indexes instance contains at least one index,
+     * {@code false} otherwise.
+     */
     public boolean hasIndex() {
         return hasIndex;
     }
 
+    /**
+     * Inserts a new queryable entry into this indexes instance or updates the
+     * existing one.
+     *
+     * @param queryableEntry the queryable entry to insert or update.
+     * @param oldValue       the old entry value to update, {@code null} if
+     *                       inserting the new entry.
+     */
     public void saveEntryIndex(QueryableEntry queryableEntry, Object oldValue) throws QueryException {
-        Index[] indexes = getIndexes();
-        for (Index index : indexes) {
+        InternalIndex[] indexes = getIndexes();
+        for (InternalIndex index : indexes) {
             index.saveEntryIndex(queryableEntry, oldValue);
+        }
+    }
+
+    /**
+     * Removes the entry from this indexes instance identified by the given key
+     * and value.
+     *
+     * @param key   the key if the entry to remove.
+     * @param value the value of the entry to remove.
+     */
+    public void removeEntryIndex(Data key, Object value) throws QueryException {
+        InternalIndex[] indexes = getIndexes();
+        for (InternalIndex index : indexes) {
+            index.removeEntryIndex(key, value);
         }
     }
 
@@ -129,23 +224,64 @@ public class Indexes {
     /**
      * Get index for a given attribute. If the index does not exist then returns null.
      *
-     * @param attribute
+     * @param attribute the attribute name to get the index of.
      * @return Index for attribute or null if the index does not exist.
      */
-    public Index getIndex(String attribute) {
+    public InternalIndex getIndex(String attribute) {
         return mapIndexes.get(attribute);
     }
 
+    /**
+     * Performs a query on this indexes instance using the given predicate.
+     *
+     * @param predicate the predicate to evaluate.
+     * @return the produced result set or {@code null} if the query can't be
+     * performed using the indexes known to this indexes instance.
+     */
+    @SuppressWarnings("unchecked")
     public Set<QueryableEntry> query(Predicate predicate) {
-        if (hasIndex) {
-            QueryContext queryContext = new QueryContext(this);
-            if (predicate instanceof IndexAwarePredicate) {
-                IndexAwarePredicate iap = (IndexAwarePredicate) predicate;
-                if (iap.isIndexed(queryContext)) {
-                    return iap.filter(queryContext);
-                }
-            }
+        stats.incrementQueryCount();
+
+        if (!hasIndex || !(predicate instanceof IndexAwarePredicate)) {
+            return null;
         }
-        return null;
+
+        IndexAwarePredicate indexAwarePredicate = (IndexAwarePredicate) predicate;
+        QueryContext queryContext = queryContextProvider.obtainContextFor(this);
+        if (!indexAwarePredicate.isIndexed(queryContext)) {
+            return null;
+        }
+
+        Set<QueryableEntry> result = indexAwarePredicate.filter(queryContext);
+        if (result != null) {
+            stats.incrementIndexedQueryCount();
+            queryContext.applyPerQueryStats();
+        }
+
+        return result;
     }
+
+    /**
+     * Returns the indexes stats of this indexes instance.
+     */
+    public InternalIndexesStats getIndexesStats() {
+        return stats;
+    }
+
+    private QueryContextProvider createQueryContextProvider(MapConfig mapConfig, boolean global) {
+        if (mapConfig.isStatisticsEnabled()) {
+            return global ? new GlobalQueryContextProviderWithStats() : new PartitionQueryContextProviderWithStats(this);
+        } else {
+            return global ? new GlobalQueryContextProvider() : new PartitionQueryContextProvider(this);
+        }
+    }
+
+    private InternalIndexesStats createStats(MapConfig mapConfig, boolean global) {
+        if (mapConfig.isStatisticsEnabled()) {
+            return global ? new GlobalIndexesStats() : new PartitionIndexesStats();
+        } else {
+            return InternalIndexesStats.EMPTY;
+        }
+    }
+
 }

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/InternalIndex.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/InternalIndex.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.hazelcast.query.impl;
 
 import com.hazelcast.monitor.impl.InternalIndexStats;

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/InternalIndex.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/InternalIndex.java
@@ -1,0 +1,15 @@
+package com.hazelcast.query.impl;
+
+import com.hazelcast.monitor.impl.InternalIndexStats;
+
+/**
+ * Provides the private index API.
+ */
+public interface InternalIndex extends Index {
+
+    /**
+     * Returns the index stats associated with this index.
+     */
+    InternalIndexStats getIndexStats();
+
+}

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/PartitionQueryContextProvider.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/PartitionQueryContextProvider.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.hazelcast.query.impl;
 
 /**

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/PartitionQueryContextProvider.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/PartitionQueryContextProvider.java
@@ -1,0 +1,25 @@
+package com.hazelcast.query.impl;
+
+/**
+ * Provides the query context support for partitioned indexes with disabled stats.
+ */
+public class PartitionQueryContextProvider implements QueryContextProvider {
+
+    private final QueryContext queryContext;
+
+    /**
+     * Constructs a new partition query context provider for the given indexes.
+     *
+     * @param indexes the indexes to construct the new query context for.
+     */
+    public PartitionQueryContextProvider(Indexes indexes) {
+        queryContext = new QueryContext(indexes);
+    }
+
+    @Override
+    public QueryContext obtainContextFor(Indexes indexes) {
+        assert indexes == queryContext.indexes;
+        return queryContext;
+    }
+
+}

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/PartitionQueryContextProviderWithStats.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/PartitionQueryContextProviderWithStats.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.hazelcast.query.impl;
 
 /**

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/PartitionQueryContextProviderWithStats.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/PartitionQueryContextProviderWithStats.java
@@ -1,0 +1,26 @@
+package com.hazelcast.query.impl;
+
+/**
+ * Provides the query context support for partitioned indexes with enabled stats.
+ */
+public class PartitionQueryContextProviderWithStats implements QueryContextProvider {
+
+    private final PartitionQueryContextWithStats queryContext;
+
+    /**
+     * Constructs a new partition query context provider with stats for the given
+     * indexes.
+     *
+     * @param indexes the indexes to construct the new query context for.
+     */
+    public PartitionQueryContextProviderWithStats(Indexes indexes) {
+        queryContext = new PartitionQueryContextWithStats(indexes);
+    }
+
+    @Override
+    public QueryContext obtainContextFor(Indexes indexes) {
+        queryContext.attachTo(indexes);
+        return queryContext;
+    }
+
+}

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/PartitionQueryContextWithStats.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/PartitionQueryContextWithStats.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.hazelcast.query.impl;
 
 import com.hazelcast.monitor.impl.InternalIndexStats;

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/PartitionQueryContextWithStats.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/PartitionQueryContextWithStats.java
@@ -1,0 +1,56 @@
+package com.hazelcast.query.impl;
+
+import com.hazelcast.monitor.impl.InternalIndexStats;
+
+import java.util.HashSet;
+
+/**
+ * Extends the basic query context to support the per-index stats tracking on
+ * behalf of partitioned indexes.
+ */
+public class PartitionQueryContextWithStats extends QueryContext {
+
+    private final HashSet<InternalIndexStats> trackedStats = new HashSet<InternalIndexStats>(8);
+
+    /**
+     * Constructs a new partition query context with stats for the given indexes.
+     *
+     * @param indexes the indexes to construct the new query context for.
+     */
+    public PartitionQueryContextWithStats(Indexes indexes) {
+        super(indexes);
+    }
+
+    @Override
+    void attachTo(Indexes indexes) {
+        assert indexes == this.indexes;
+        for (InternalIndexStats stats : trackedStats) {
+            stats.resetPerQueryStats();
+        }
+        trackedStats.clear();
+    }
+
+    @Override
+    public Index getIndex(String attributeName) {
+        if (indexes == null) {
+            return null;
+        }
+
+        InternalIndex index = indexes.getIndex(attributeName);
+        if (index == null) {
+            return null;
+        }
+
+        trackedStats.add(index.getIndexStats());
+
+        return index;
+    }
+
+    @Override
+    void applyPerQueryStats() {
+        for (InternalIndexStats stats : trackedStats) {
+            stats.incrementQueryCount();
+        }
+    }
+
+}

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/QueryContext.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/QueryContext.java
@@ -20,7 +20,7 @@ package com.hazelcast.query.impl;
  * Provides the context for queries execution.
  */
 public class QueryContext {
-    private final Indexes indexes;
+    protected Indexes indexes;
 
     /**
      * Creates a new query context with the given available indexes.
@@ -28,6 +28,21 @@ public class QueryContext {
      * @param indexes the indexes available for the query context.
      */
     public QueryContext(Indexes indexes) {
+        this.indexes = indexes;
+    }
+
+    /**
+     * Creates a new query context unattached to any indexes.
+     */
+    QueryContext() {
+    }
+
+    /**
+     * Attaches this index context to the given indexes.
+     *
+     * @param indexes the indexes to attach to.
+     */
+    void attachTo(Indexes indexes) {
         this.indexes = indexes;
     }
 
@@ -46,4 +61,12 @@ public class QueryContext {
             return indexes.getIndex(attributeName);
         }
     }
+
+    /**
+     * Applies the collected per-query stats, if any.
+     */
+    void applyPerQueryStats() {
+        // do nothing
+    }
+
 }

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/QueryContextProvider.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/QueryContextProvider.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.hazelcast.query.impl;
 
 /**

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/QueryContextProvider.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/QueryContextProvider.java
@@ -1,0 +1,19 @@
+package com.hazelcast.query.impl;
+
+/**
+ * Provides query contexts for {@link Indexes} to execute queries.
+ */
+public interface QueryContextProvider {
+
+    /**
+     * Obtains a query context for the given indexes.
+     * <p>
+     * The returned query context instance is valid for a duration of a single
+     * query and should be re-obtained for every query.
+     *
+     * @param indexes the indexes to obtain the query context for.
+     * @return the obtained query context.
+     */
+    QueryContext obtainContextFor(Indexes indexes);
+
+}

--- a/hazelcast/src/test/java/com/hazelcast/map/LocalIndexStatsTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/LocalIndexStatsTest.java
@@ -278,15 +278,61 @@ public class LocalIndexStatsTest extends HazelcastTestSupport {
         for (int i = 0; i < QUERIES; ++i) {
             map.entrySet(Predicates.equal("__key", 10));
             map.entrySet(Predicates.equal("this", 10));
-            assertEquals(expected, keyStats().getAverageHitSelectivity(), 0.01);
-            assertEquals(expected, valueStats().getAverageHitSelectivity(), 0.01);
+            assertEquals(expected, keyStats().getAverageHitSelectivity(), 0.015);
+            assertEquals(expected, valueStats().getAverageHitSelectivity(), 0.015);
         }
 
         for (int i = 1; i <= QUERIES; ++i) {
             map.entrySet(Predicates.greaterEqual("__key", entryCount / 2));
             map.entrySet(Predicates.greaterEqual("this", entryCount / 2));
-            assertEquals((expected * QUERIES + 0.5 * i) / (QUERIES + i), keyStats().getAverageHitSelectivity(), 0.01);
-            assertEquals((expected * QUERIES + 0.5 * i) / (QUERIES + i), valueStats().getAverageHitSelectivity(), 0.01);
+            assertEquals((expected * QUERIES + 0.5 * i) / (QUERIES + i), keyStats().getAverageHitSelectivity(), 0.015);
+            assertEquals((expected * QUERIES + 0.5 * i) / (QUERIES + i), valueStats().getAverageHitSelectivity(), 0.015);
+        }
+    }
+
+    @Test
+    public void testAverageQuerySelectivityCalculation_ChangingNumberOfIndex() {
+        double expected1 = 1.0 - 0.01;
+        double expected2 = 1.0 - 0.1;
+        double expected3 = 1.0 - 0.4;
+
+        map.addIndex("__key", false);
+        map.addIndex("this", true);
+        for (int i = 0; i < 100; ++i) {
+            map.put(i, i);
+        }
+        assertEquals(0.0, keyStats().getAverageHitSelectivity(), 0.0);
+        assertEquals(0.0, valueStats().getAverageHitSelectivity(), 0.0);
+
+        for (int i = 0; i < QUERIES; ++i) {
+            map.entrySet(Predicates.equal("__key", 10));
+            map.entrySet(Predicates.equal("this", 10));
+            assertEquals(expected1, keyStats().getAverageHitSelectivity(), 0.015);
+            assertEquals(expected1, valueStats().getAverageHitSelectivity(), 0.015);
+        }
+
+        for (int i = 100; i < 200; ++i) {
+            map.put(i, i);
+        }
+
+        for (int i = 1; i <= QUERIES; ++i) {
+            map.entrySet(Predicates.greaterEqual("__key", 180));
+            map.entrySet(Predicates.greaterEqual("this", 180));
+            assertEquals((expected1 * QUERIES + expected2 * i) / (QUERIES + i), keyStats().getAverageHitSelectivity(), 0.015);
+            assertEquals((expected1 * QUERIES + expected2 * i) / (QUERIES + i), valueStats().getAverageHitSelectivity(), 0.015);
+        }
+
+        for (int i = 150; i < 200; ++i) {
+            map.remove(i);
+        }
+
+        for (int i = 1; i <= QUERIES; ++i) {
+            map.entrySet(Predicates.greaterEqual("__key", 90));
+            map.entrySet(Predicates.greaterEqual("this", 90));
+            assertEquals(((expected1 + expected2) * QUERIES + expected3 * i) / (2 * QUERIES + i),
+                    keyStats().getAverageHitSelectivity(), 0.015);
+            assertEquals(((expected1 + expected2) * QUERIES + expected3 * i) / (2 * QUERIES + i),
+                    valueStats().getAverageHitSelectivity(), 0.015);
         }
     }
 
@@ -419,6 +465,14 @@ public class LocalIndexStatsTest extends HazelcastTestSupport {
             assertTrue(keyStats().getAverageHitLatency() > 0);
             assertTrue(keyStats().getAverageHitLatency() <= totalMeasuredLatency / i);
         }
+
+        long originalAvgHitLatency = keyStats().getAverageHitLatency();
+        for (int i = 1; i <= QUERIES; ++i) {
+            map.entrySet(Predicates.alwaysTrue());
+        }
+        long avgHitLatencyAfterNonIndexedQueries = keyStats().getAverageHitLatency();
+        assertEquals(originalAvgHitLatency, avgHitLatencyAfterNonIndexedQueries);
+
     }
 
     @Test
@@ -428,14 +482,17 @@ public class LocalIndexStatsTest extends HazelcastTestSupport {
         assertEquals(0, keyStats().getTotalInsertLatency());
 
         long totalMeasuredLatency = 0;
+        long previousTotalInsertLatency = 0;
         for (int i = 1; i <= 100; ++i) {
             long start = System.nanoTime();
             map.put(i, i);
             totalMeasuredLatency += System.nanoTime() - start;
 
             assertEquals(i, keyStats().getInsertCount());
-            assertTrue(keyStats().getTotalInsertLatency() > 0);
+            assertTrue(keyStats().getTotalInsertLatency() > previousTotalInsertLatency);
             assertTrue(keyStats().getTotalInsertLatency() <= totalMeasuredLatency);
+
+            previousTotalInsertLatency = keyStats().getTotalInsertLatency();
         }
 
         assertEquals(0, keyStats().getUpdateCount());
@@ -455,14 +512,17 @@ public class LocalIndexStatsTest extends HazelcastTestSupport {
         assertEquals(0, keyStats().getTotalUpdateLatency());
 
         long totalMeasuredLatency = 0;
+        long previousTotalUpdateLatency = 0;
         for (int i = 1; i <= 50; ++i) {
             long start = System.nanoTime();
             map.put(i, i * 2);
             totalMeasuredLatency += System.nanoTime() - start;
 
             assertEquals(i, keyStats().getUpdateCount());
-            assertTrue(keyStats().getTotalUpdateLatency() > 0);
+            assertTrue(keyStats().getTotalUpdateLatency() > previousTotalUpdateLatency);
             assertTrue(keyStats().getTotalUpdateLatency() <= totalMeasuredLatency);
+
+            previousTotalUpdateLatency = keyStats().getTotalUpdateLatency();
         }
 
         assertEquals(100, keyStats().getInsertCount());
@@ -482,18 +542,70 @@ public class LocalIndexStatsTest extends HazelcastTestSupport {
         assertEquals(0, keyStats().getTotalRemoveLatency());
 
         long totalMeasuredLatency = 0;
+        long previousTotalRemoveLatency = 0;
         for (int i = 1; i <= 50; ++i) {
             long start = System.nanoTime();
             map.remove(i);
             totalMeasuredLatency += System.nanoTime() - start;
 
             assertEquals(i, keyStats().getRemoveCount());
-            assertTrue(keyStats().getTotalRemoveLatency() > 0);
+            assertTrue(keyStats().getTotalRemoveLatency() > previousTotalRemoveLatency);
             assertTrue(keyStats().getTotalRemoveLatency() <= totalMeasuredLatency);
+
+            previousTotalRemoveLatency = keyStats().getTotalRemoveLatency();
         }
 
         assertEquals(100, keyStats().getInsertCount());
         assertEquals(0, keyStats().getUpdateCount());
+    }
+
+    @Test
+    public void testInsertUpdateRemoveAreNotEffectEachOther() {
+        map.addIndex("__key", false);
+        assertEquals(0, keyStats().getInsertCount());
+        assertEquals(0, keyStats().getUpdateCount());
+        assertEquals(0, keyStats().getRemoveCount());
+
+        long originalTotalInsertLatency = keyStats().getTotalInsertLatency();
+        long originalTotalUpdateLatency = keyStats().getTotalUpdateLatency();
+        long originalTotalRemoveLatency = keyStats().getTotalRemoveLatency();
+
+        for (int i = 1; i <= 100; ++i) {
+            map.put(i, i);
+        }
+
+        assertTrue(keyStats().getTotalInsertLatency() > originalTotalInsertLatency);
+        assertEquals(originalTotalUpdateLatency, keyStats().getTotalUpdateLatency());
+        assertEquals(originalTotalRemoveLatency, keyStats().getTotalRemoveLatency());
+
+        originalTotalInsertLatency = keyStats().getTotalInsertLatency();
+        originalTotalUpdateLatency = keyStats().getTotalUpdateLatency();
+        originalTotalRemoveLatency = keyStats().getTotalRemoveLatency();
+
+        for (int i = 1; i <= 50; ++i) {
+            map.put(i, i * 2);
+        }
+
+        assertEquals(originalTotalInsertLatency, keyStats().getTotalInsertLatency());
+        assertTrue(keyStats().getTotalUpdateLatency() > originalTotalUpdateLatency);
+        assertEquals(originalTotalRemoveLatency, keyStats().getTotalRemoveLatency());
+
+        originalTotalInsertLatency = keyStats().getTotalInsertLatency();
+        originalTotalUpdateLatency = keyStats().getTotalUpdateLatency();
+        originalTotalRemoveLatency = keyStats().getTotalRemoveLatency();
+
+        for (int i = 1; i <= 20; ++i) {
+            map.remove(i);
+        }
+
+        assertEquals(originalTotalInsertLatency, keyStats().getTotalInsertLatency());
+        assertEquals(originalTotalUpdateLatency, keyStats().getTotalUpdateLatency());
+        assertTrue(keyStats().getTotalRemoveLatency() > originalTotalRemoveLatency);
+
+        assertEquals(100, keyStats().getInsertCount());
+        assertEquals(50, keyStats().getUpdateCount());
+        assertEquals(20, keyStats().getRemoveCount());
+
     }
 
     protected LocalMapStats stats() {

--- a/hazelcast/src/test/java/com/hazelcast/map/LocalIndexStatsTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/LocalIndexStatsTest.java
@@ -632,7 +632,7 @@ public class LocalIndexStatsTest extends HazelcastTestSupport {
             public void query(Predicate predicate) {
                 map.project(Projections.singleAttribute("this"), predicate);
             }
-        }};
+        }, };
     }
 
 }

--- a/hazelcast/src/test/java/com/hazelcast/map/LocalIndexStatsTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/LocalIndexStatsTest.java
@@ -1,0 +1,638 @@
+/*
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.map;
+
+import com.hazelcast.aggregation.Aggregators;
+import com.hazelcast.config.Config;
+import com.hazelcast.config.InMemoryFormat;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.core.IMap;
+import com.hazelcast.monitor.LocalIndexStats;
+import com.hazelcast.monitor.LocalMapStats;
+import com.hazelcast.projection.Projections;
+import com.hazelcast.query.PartitionPredicate;
+import com.hazelcast.query.Predicate;
+import com.hazelcast.query.Predicates;
+import com.hazelcast.spi.properties.GroupProperty;
+import com.hazelcast.test.HazelcastParallelParametersRunnerFactory;
+import com.hazelcast.test.HazelcastTestSupport;
+import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameter;
+import org.junit.runners.Parameterized.Parameters;
+import org.junit.runners.Parameterized.UseParametersRunnerFactory;
+
+import java.util.Collection;
+
+import static java.util.Arrays.asList;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+@RunWith(Parameterized.class)
+@UseParametersRunnerFactory(HazelcastParallelParametersRunnerFactory.class)
+@Category({QuickTest.class, ParallelTest.class})
+public class LocalIndexStatsTest extends HazelcastTestSupport {
+
+    @Parameters(name = "format:{0}")
+    public static Collection<Object[]> parameters() {
+        return asList(new Object[][]{{InMemoryFormat.OBJECT}, {InMemoryFormat.BINARY}});
+    }
+
+    @Parameter
+    public InMemoryFormat inMemoryFormat;
+
+    private static final int PARTITIONS = 137;
+
+    private static final int QUERIES = 10;
+
+    private QueryType[] queryTypes;
+
+    protected String mapName;
+
+    protected String noStatsMapName;
+
+    protected HazelcastInstance instance;
+
+    protected IMap<Integer, Integer> map;
+
+    protected IMap<Integer, Integer> noStatsMap;
+
+    @Before
+    public void before() {
+        mapName = randomMapName();
+        noStatsMapName = mapName + "_no_stats";
+
+        Config config = getConfig();
+        config.setProperty(GroupProperty.PARTITION_COUNT.getName(), Integer.toString(PARTITIONS));
+        config.getMapConfig(mapName).setInMemoryFormat(inMemoryFormat);
+        config.getMapConfig(noStatsMapName).setStatisticsEnabled(false);
+
+        instance = createInstance(config);
+        map = instance.getMap(mapName);
+        noStatsMap = instance.getMap(noStatsMapName);
+        queryTypes = initQueryTypes();
+    }
+
+    protected HazelcastInstance createInstance(Config config) {
+        return createHazelcastInstance(config);
+    }
+
+    @Test
+    public void testQueryCounting() {
+        map.addIndex("this", false);
+        for (int i = 0; i < 100; ++i) {
+            map.put(i, i);
+        }
+
+        long expectedQueryCount = 0;
+        long expectedIndexedQueryCount = 0;
+
+        assertEquals(expectedQueryCount, stats().getQueryCount());
+        assertEquals(expectedIndexedQueryCount, stats().getIndexedQueryCount());
+        for (QueryType queryType : queryTypes) {
+            query(queryType, Predicates.alwaysTrue(), Predicates.equal("this", 10));
+
+            expectedQueryCount += QUERIES * 2;
+            if (queryType.isIndexed()) {
+                expectedIndexedQueryCount += QUERIES;
+            }
+
+            assertEquals(expectedQueryCount, stats().getQueryCount());
+            assertEquals(expectedIndexedQueryCount, stats().getIndexedQueryCount());
+        }
+    }
+
+    @Test
+    public void testHitAndQueryCounting_WhenAllIndexesHit() {
+        map.addIndex("__key", false);
+        map.addIndex("this", true);
+        for (int i = 0; i < 100; ++i) {
+            map.put(i, i);
+        }
+
+        long expectedKeyHitCount = 0;
+        long expectedKeyQueryCount = 0;
+        long expectedValueHitCount = 0;
+        long expectedValueQueryCount = 0;
+
+        assertEquals(expectedKeyHitCount, keyStats().getHitCount());
+        assertEquals(expectedKeyQueryCount, keyStats().getQueryCount());
+        assertEquals(expectedValueHitCount, valueStats().getHitCount());
+        assertEquals(expectedValueQueryCount, valueStats().getQueryCount());
+        for (QueryType queryType : queryTypes) {
+            query(queryType, Predicates.alwaysTrue(), Predicates.equal("__key", 10), Predicates.equal("this", 10));
+
+            if (queryType.isIndexed()) {
+                expectedKeyHitCount += QUERIES;
+                expectedKeyQueryCount += QUERIES;
+                expectedValueHitCount += QUERIES;
+                expectedValueQueryCount += QUERIES;
+            }
+
+            assertEquals(expectedKeyHitCount, keyStats().getHitCount());
+            assertEquals(expectedKeyQueryCount, keyStats().getQueryCount());
+            assertEquals(expectedValueHitCount, valueStats().getHitCount());
+            assertEquals(expectedValueQueryCount, valueStats().getQueryCount());
+        }
+    }
+
+    @Test
+    public void testHitAndQueryCounting_WhenSingleIndexHit() {
+        map.addIndex("__key", false);
+        map.addIndex("this", true);
+        for (int i = 0; i < 100; ++i) {
+            map.put(i, i);
+        }
+
+        long expectedKeyHitCount = 0;
+        long expectedKeyQueryCount = 0;
+
+        assertEquals(expectedKeyHitCount, keyStats().getHitCount());
+        assertEquals(expectedKeyQueryCount, keyStats().getQueryCount());
+        assertEquals(0, valueStats().getHitCount());
+        assertEquals(0, valueStats().getQueryCount());
+        for (QueryType queryType : queryTypes) {
+            query(queryType, Predicates.alwaysTrue(), Predicates.equal("__key", 10));
+
+            if (queryType.isIndexed()) {
+                expectedKeyHitCount += QUERIES;
+                expectedKeyQueryCount += QUERIES;
+            }
+
+            assertEquals(expectedKeyHitCount, keyStats().getHitCount());
+            assertEquals(expectedKeyQueryCount, keyStats().getQueryCount());
+            assertEquals(0, valueStats().getHitCount());
+            assertEquals(0, valueStats().getQueryCount());
+        }
+    }
+
+    @Test
+    public void testHitCounting_WhenIndexHitMultipleTimes() {
+        map.addIndex("__key", false);
+        map.addIndex("this", true);
+        for (int i = 0; i < 100; ++i) {
+            map.put(i, i);
+        }
+
+        long expectedKeyHitCount = 0;
+        long expectedKeyQueryCount = 0;
+        long expectedValueHitCount = 0;
+        long expectedValueQueryCount = 0;
+
+        assertEquals(expectedKeyHitCount, keyStats().getHitCount());
+        assertEquals(expectedKeyQueryCount, keyStats().getQueryCount());
+        assertEquals(expectedValueHitCount, valueStats().getHitCount());
+        assertEquals(expectedValueQueryCount, valueStats().getQueryCount());
+        for (QueryType queryType : queryTypes) {
+            query(queryType, Predicates.alwaysTrue(), Predicates.or(Predicates.equal("__key", 10), Predicates.equal("__key", 20)),
+                    Predicates.equal("this", 10));
+
+            if (queryType.isIndexed()) {
+                expectedKeyHitCount += QUERIES * 2;
+                expectedKeyQueryCount += QUERIES;
+                expectedValueHitCount += QUERIES;
+                expectedValueQueryCount += QUERIES;
+            }
+
+            assertEquals(expectedKeyHitCount, keyStats().getHitCount());
+            assertEquals(expectedKeyQueryCount, keyStats().getQueryCount());
+            assertEquals(expectedValueHitCount, valueStats().getHitCount());
+            assertEquals(expectedValueQueryCount, valueStats().getQueryCount());
+        }
+    }
+
+    @Test
+    public void testEntryCounting() {
+        map.addIndex("__key", false);
+        map.addIndex("this", true);
+        for (int i = 0; i < 100; ++i) {
+            map.put(i, i);
+        }
+        assertEquals(100, keyStats().getEntryCount());
+        assertEquals(100, valueStats().getEntryCount());
+
+        for (int i = 50; i < 100; ++i) {
+            map.remove(i);
+        }
+        assertEquals(50, keyStats().getEntryCount());
+        assertEquals(50, valueStats().getEntryCount());
+
+        for (int i = 0; i < 50; ++i) {
+            map.put(i, i * i);
+        }
+        assertEquals(50, keyStats().getEntryCount());
+        assertEquals(50, valueStats().getEntryCount());
+
+        for (int i = 50; i < 100; ++i) {
+            map.set(i, i);
+        }
+        assertEquals(100, keyStats().getEntryCount());
+        assertEquals(100, valueStats().getEntryCount());
+    }
+
+    @Test
+    public void testAverageQuerySelectivityCalculation_WhenSomePartitionsAreEmpty() {
+        testAverageQuerySelectivityCalculation(100);
+    }
+
+    @Test
+    public void testAverageQuerySelectivityCalculation_WhenAllPartitionsArePopulated() {
+        testAverageQuerySelectivityCalculation(1000);
+    }
+
+    @Test
+    public void testAverageQuerySelectivityCalculation_WhenAllPartitionsAreHeavilyPopulated() {
+        testAverageQuerySelectivityCalculation(10000);
+    }
+
+    private void testAverageQuerySelectivityCalculation(int entryCount) {
+        double expected = 1.0 - 1.0 / entryCount;
+
+        map.addIndex("__key", false);
+        map.addIndex("this", true);
+        for (int i = 0; i < entryCount; ++i) {
+            map.put(i, i);
+        }
+        assertEquals(0.0, keyStats().getAverageHitSelectivity(), 0.0);
+        assertEquals(0.0, valueStats().getAverageHitSelectivity(), 0.0);
+
+        for (int i = 0; i < QUERIES; ++i) {
+            map.entrySet(Predicates.equal("__key", 10));
+            map.entrySet(Predicates.equal("this", 10));
+            assertEquals(expected, keyStats().getAverageHitSelectivity(), 0.01);
+            assertEquals(expected, valueStats().getAverageHitSelectivity(), 0.01);
+        }
+
+        for (int i = 1; i <= QUERIES; ++i) {
+            map.entrySet(Predicates.greaterEqual("__key", entryCount / 2));
+            map.entrySet(Predicates.greaterEqual("this", entryCount / 2));
+            assertEquals((expected * QUERIES + 0.5 * i) / (QUERIES + i), keyStats().getAverageHitSelectivity(), 0.01);
+            assertEquals((expected * QUERIES + 0.5 * i) / (QUERIES + i), valueStats().getAverageHitSelectivity(), 0.01);
+        }
+    }
+
+    @Test
+    public void testQueryCounting_WhenTwoMapsUseIndexesNamedTheSame() {
+        map.addIndex("__key", false);
+        map.addIndex("this", true);
+
+        IMap<Integer, Integer> otherMap = instance.getMap(map.getName() + "_other_map");
+        otherMap.addIndex("__key", false);
+        otherMap.addIndex("this", true);
+
+        for (int i = 0; i < 100; ++i) {
+            otherMap.put(i, i);
+        }
+        assertEquals(0, keyStats().getEntryCount());
+        assertEquals(0, valueStats().getEntryCount());
+
+        otherMap.entrySet(Predicates.equal("__key", 10));
+        assertEquals(0, keyStats().getQueryCount());
+        assertEquals(0, valueStats().getQueryCount());
+
+        map.entrySet(Predicates.equal("__key", 10));
+        assertEquals(1, keyStats().getQueryCount());
+        assertEquals(0, valueStats().getQueryCount());
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    public void testQueryCounting_WhenPartitionPredicateIsUsed() {
+        map.addIndex("this", false);
+
+        for (int i = 0; i < 100; ++i) {
+            map.put(i, i);
+        }
+
+        map.entrySet(new PartitionPredicate(10, Predicates.equal("this", 10)));
+        assertEquals(1, stats().getQueryCount());
+        assertEquals(0, stats().getIndexedQueryCount());
+        assertEquals(0, valueStats().getQueryCount());
+    }
+
+    @Test
+    public void testQueryCounting_WhenStatisticsIsDisabled() {
+        map.addIndex("__key", false);
+        map.addIndex("this", true);
+
+        noStatsMap.addIndex("__key", false);
+        noStatsMap.addIndex("this", true);
+
+        for (int i = 0; i < 100; ++i) {
+            noStatsMap.put(i, i);
+        }
+        assertEquals(0, noStats().getQueryCount());
+        assertEquals(0, stats().getQueryCount());
+
+        noStatsMap.entrySet(Predicates.equal("__key", 10));
+        assertEquals(0, noStats().getQueryCount());
+        assertEquals(0, stats().getQueryCount());
+
+        map.entrySet(Predicates.equal("__key", 10));
+        assertEquals(0, noStats().getQueryCount());
+        assertEquals(1, stats().getQueryCount());
+    }
+
+    @Test
+    public void testMemoryCostTracking() {
+        map.addIndex("__key", false);
+        map.addIndex("this", true);
+        long keyEmptyCost = keyStats().getOnHeapMemoryCost();
+        long valueEmptyCost = valueStats().getOnHeapMemoryCost();
+        assertTrue(keyEmptyCost > 0);
+        assertTrue(valueEmptyCost > 0);
+        assertEquals(0, keyStats().getOffHeapMemoryCost());
+        assertEquals(0, valueStats().getOffHeapMemoryCost());
+
+        for (int i = 0; i < 100; ++i) {
+            map.put(i, i);
+        }
+        long keyFullCost = keyStats().getOnHeapMemoryCost();
+        long valueFullCost = valueStats().getOnHeapMemoryCost();
+        assertTrue(keyFullCost > keyEmptyCost);
+        assertTrue(valueFullCost > valueEmptyCost);
+        assertEquals(0, keyStats().getOffHeapMemoryCost());
+        assertEquals(0, valueStats().getOffHeapMemoryCost());
+
+        for (int i = 0; i < 50; ++i) {
+            map.remove(i);
+        }
+        long keyHalfFullCost = keyStats().getOnHeapMemoryCost();
+        long valueHalfFullCost = valueStats().getOnHeapMemoryCost();
+        assertTrue(keyHalfFullCost > keyEmptyCost && keyHalfFullCost < keyFullCost);
+        assertTrue(valueHalfFullCost > valueEmptyCost && valueHalfFullCost < valueFullCost);
+        assertEquals(0, keyStats().getOffHeapMemoryCost());
+        assertEquals(0, valueStats().getOffHeapMemoryCost());
+
+        for (int i = 0; i < 50; ++i) {
+            map.put(i, i);
+        }
+        assertTrue(keyStats().getOnHeapMemoryCost() > keyHalfFullCost);
+        assertTrue(valueStats().getOnHeapMemoryCost() > valueHalfFullCost);
+        assertEquals(0, keyStats().getOffHeapMemoryCost());
+        assertEquals(0, valueStats().getOffHeapMemoryCost());
+
+        for (int i = 0; i < 50; ++i) {
+            map.set(i, i * i);
+        }
+        assertTrue(keyStats().getOnHeapMemoryCost() > keyHalfFullCost);
+        assertTrue(valueStats().getOnHeapMemoryCost() > valueHalfFullCost);
+        assertEquals(0, keyStats().getOffHeapMemoryCost());
+        assertEquals(0, valueStats().getOffHeapMemoryCost());
+    }
+
+    @Test
+    public void testAverageQueryLatencyTracking() {
+        map.addIndex("__key", false);
+        assertEquals(0, keyStats().getAverageHitLatency());
+
+        for (int i = 0; i < 100; ++i) {
+            map.put(i, i);
+        }
+        assertEquals(0, keyStats().getAverageHitLatency());
+
+        long totalMeasuredLatency = 0;
+        for (int i = 1; i <= QUERIES; ++i) {
+            long start = System.nanoTime();
+            map.entrySet(Predicates.equal("__key", i));
+            totalMeasuredLatency += System.nanoTime() - start;
+
+            assertTrue(keyStats().getAverageHitLatency() > 0);
+            assertTrue(keyStats().getAverageHitLatency() <= totalMeasuredLatency / i);
+        }
+    }
+
+    @Test
+    public void testInsertsTracking() {
+        map.addIndex("__key", false);
+        assertEquals(0, keyStats().getInsertCount());
+        assertEquals(0, keyStats().getTotalInsertLatency());
+
+        long totalMeasuredLatency = 0;
+        for (int i = 1; i <= 100; ++i) {
+            long start = System.nanoTime();
+            map.put(i, i);
+            totalMeasuredLatency += System.nanoTime() - start;
+
+            assertEquals(i, keyStats().getInsertCount());
+            assertTrue(keyStats().getTotalInsertLatency() > 0);
+            assertTrue(keyStats().getTotalInsertLatency() <= totalMeasuredLatency);
+        }
+
+        assertEquals(0, keyStats().getUpdateCount());
+        assertEquals(0, keyStats().getRemoveCount());
+    }
+
+    @Test
+    public void testUpdateTracking() {
+        map.addIndex("__key", false);
+        assertEquals(0, keyStats().getUpdateCount());
+        assertEquals(0, keyStats().getTotalUpdateLatency());
+
+        for (int i = 1; i <= 100; ++i) {
+            map.put(i, i);
+        }
+        assertEquals(0, keyStats().getUpdateCount());
+        assertEquals(0, keyStats().getTotalUpdateLatency());
+
+        long totalMeasuredLatency = 0;
+        for (int i = 1; i <= 50; ++i) {
+            long start = System.nanoTime();
+            map.put(i, i * 2);
+            totalMeasuredLatency += System.nanoTime() - start;
+
+            assertEquals(i, keyStats().getUpdateCount());
+            assertTrue(keyStats().getTotalUpdateLatency() > 0);
+            assertTrue(keyStats().getTotalUpdateLatency() <= totalMeasuredLatency);
+        }
+
+        assertEquals(100, keyStats().getInsertCount());
+        assertEquals(0, keyStats().getRemoveCount());
+    }
+
+    @Test
+    public void testRemoveTracking() {
+        map.addIndex("__key", false);
+        assertEquals(0, keyStats().getRemoveCount());
+        assertEquals(0, keyStats().getTotalRemoveLatency());
+
+        for (int i = 1; i <= 100; ++i) {
+            map.put(i, i);
+        }
+        assertEquals(0, keyStats().getRemoveCount());
+        assertEquals(0, keyStats().getTotalRemoveLatency());
+
+        long totalMeasuredLatency = 0;
+        for (int i = 1; i <= 50; ++i) {
+            long start = System.nanoTime();
+            map.remove(i);
+            totalMeasuredLatency += System.nanoTime() - start;
+
+            assertEquals(i, keyStats().getRemoveCount());
+            assertTrue(keyStats().getTotalRemoveLatency() > 0);
+            assertTrue(keyStats().getTotalRemoveLatency() <= totalMeasuredLatency);
+        }
+
+        assertEquals(100, keyStats().getInsertCount());
+        assertEquals(0, keyStats().getUpdateCount());
+    }
+
+    protected LocalMapStats stats() {
+        return map.getLocalMapStats();
+    }
+
+    protected LocalMapStats noStats() {
+        return noStatsMap.getLocalMapStats();
+    }
+
+    protected LocalIndexStats keyStats() {
+        return stats().getIndexStats().get("__key");
+    }
+
+    protected LocalIndexStats valueStats() {
+        return stats().getIndexStats().get("this");
+    }
+
+    private void query(QueryType queryType, Predicate... predicates) {
+        for (int i = 0; i < QUERIES; ++i) {
+            for (Predicate predicate : predicates) {
+                queryType.query(predicate);
+            }
+        }
+    }
+
+    private interface QueryType {
+
+        boolean isIndexed();
+
+        void query(Predicate predicate);
+
+    }
+
+    @SuppressWarnings("unchecked")
+    private QueryType[] initQueryTypes() {
+        final IMap map = this.map;
+
+        return new QueryType[]{new QueryType() {
+            @Override
+            public boolean isIndexed() {
+                return false;
+            }
+
+            @Override
+            public void query(Predicate predicate) {
+                map.entrySet();
+            }
+        }, new QueryType() {
+            @Override
+            public boolean isIndexed() {
+                return true;
+            }
+
+            @Override
+            public void query(Predicate predicate) {
+                map.entrySet(predicate);
+            }
+        }, new QueryType() {
+            @Override
+            public boolean isIndexed() {
+                return false;
+            }
+
+            @Override
+            public void query(Predicate predicate) {
+                map.values();
+            }
+        }, new QueryType() {
+            @Override
+            public boolean isIndexed() {
+                return true;
+            }
+
+            @Override
+            public void query(Predicate predicate) {
+                map.values(predicate);
+            }
+        }, new QueryType() {
+            @Override
+            public boolean isIndexed() {
+                return false;
+            }
+
+            @Override
+            public void query(Predicate predicate) {
+                map.keySet();
+            }
+        }, new QueryType() {
+            @Override
+            public boolean isIndexed() {
+                return true;
+            }
+
+            @Override
+            public void query(Predicate predicate) {
+                map.keySet(predicate);
+            }
+        }, new QueryType() {
+            @Override
+            public boolean isIndexed() {
+                return false;
+            }
+
+            @Override
+            public void query(Predicate predicate) {
+                map.aggregate(Aggregators.count());
+            }
+        }, new QueryType() {
+            @Override
+            public boolean isIndexed() {
+                return true;
+            }
+
+            @Override
+            public void query(Predicate predicate) {
+                map.aggregate(Aggregators.count(), predicate);
+            }
+        }, new QueryType() {
+            @Override
+            public boolean isIndexed() {
+                return false;
+            }
+
+            @Override
+            public void query(Predicate predicate) {
+                map.project(Projections.singleAttribute("this"));
+            }
+        }, new QueryType() {
+            @Override
+            public boolean isIndexed() {
+                return true;
+            }
+
+            @Override
+            public void query(Predicate predicate) {
+                map.project(Projections.singleAttribute("this"), predicate);
+            }
+        }};
+    }
+
+}

--- a/hazelcast/src/test/java/com/hazelcast/monitor/impl/LocalIndexStatsImplTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/monitor/impl/LocalIndexStatsImplTest.java
@@ -1,0 +1,81 @@
+package com.hazelcast.monitor.impl;
+
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelTest.class})
+public class LocalIndexStatsImplTest {
+
+    private LocalIndexStatsImpl stats;
+
+    @Before
+    public void setUp() {
+        stats = new LocalIndexStatsImpl();
+
+        stats.setCreationTime(1234);
+        stats.setHitCount(20);
+        stats.setQueryCount(11);
+        stats.setEntryCount(100);
+        stats.setAverageHitSelectivity(0.5);
+        stats.setAverageHitLatency(81273);
+        stats.setInsertCount(91238);
+        stats.setTotalInsertLatency(83912);
+        stats.setUpdateCount(712639);
+        stats.setTotalUpdateLatency(34623);
+        stats.setRemoveCount(749274);
+        stats.setTotalRemoveLatency(1454957);
+        stats.setOnHeapMemoryCost(2345);
+        stats.setOffHeapMemoryCost(3456);
+    }
+
+    @Test
+    public void testDefaultConstructor() {
+        assertEquals(1234, stats.getCreationTime());
+        assertEquals(20, stats.getHitCount());
+        assertEquals(11, stats.getQueryCount());
+        assertEquals(100, stats.getEntryCount());
+        assertEquals(0.5, stats.getAverageHitSelectivity(), 0.01);
+        assertEquals(81273, stats.getAverageHitLatency());
+        assertEquals(91238, stats.getInsertCount());
+        assertEquals(83912, stats.getTotalInsertLatency());
+        assertEquals(712639, stats.getUpdateCount());
+        assertEquals(34623, stats.getTotalUpdateLatency());
+        assertEquals(749274, stats.getRemoveCount());
+        assertEquals(1454957, stats.getTotalRemoveLatency());
+        assertEquals(2345, stats.getOnHeapMemoryCost());
+        assertEquals(3456, stats.getOffHeapMemoryCost());
+        assertNotNull(stats.toString());
+    }
+
+    @Test
+    public void testSerialization() {
+        LocalIndexStatsImpl deserialized = new LocalIndexStatsImpl();
+        deserialized.fromJson(stats.toJson());
+
+        assertEquals(1234, deserialized.getCreationTime());
+        assertEquals(20, deserialized.getHitCount());
+        assertEquals(11, deserialized.getQueryCount());
+        assertEquals(100, deserialized.getEntryCount());
+        assertEquals(0.5, deserialized.getAverageHitSelectivity(), 0.01);
+        assertEquals(81273, deserialized.getAverageHitLatency());
+        assertEquals(91238, deserialized.getInsertCount());
+        assertEquals(83912, deserialized.getTotalInsertLatency());
+        assertEquals(712639, deserialized.getUpdateCount());
+        assertEquals(34623, deserialized.getTotalUpdateLatency());
+        assertEquals(749274, deserialized.getRemoveCount());
+        assertEquals(1454957, deserialized.getTotalRemoveLatency());
+        assertEquals(2345, deserialized.getOnHeapMemoryCost());
+        assertEquals(3456, deserialized.getOffHeapMemoryCost());
+        assertNotNull(deserialized.toString());
+    }
+
+}

--- a/hazelcast/src/test/java/com/hazelcast/monitor/impl/LocalIndexStatsImplTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/monitor/impl/LocalIndexStatsImplTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.hazelcast.monitor.impl;
 
 import com.hazelcast.test.HazelcastParallelClassRunner;

--- a/hazelcast/src/test/java/com/hazelcast/monitor/impl/LocalMapStatsImplTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/monitor/impl/LocalMapStatsImplTest.java
@@ -25,6 +25,9 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
+import java.util.HashMap;
+import java.util.Map;
+
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
@@ -67,6 +70,13 @@ public class LocalMapStatsImplTest {
 
         localMapStats.setHeapCost(7461762);
         localMapStats.setNearCacheStats(new NearCacheStatsImpl());
+
+        localMapStats.setQueryCount(10);
+        localMapStats.setIndexedQueryCount(5);
+        Map<String, LocalIndexStatsImpl> indexStats = new HashMap<String, LocalIndexStatsImpl>();
+        LocalIndexStatsImpl index = new LocalIndexStatsImpl();
+        indexStats.put("index", index);
+        localMapStats.setIndexStats(indexStats);
     }
 
     @Test
@@ -99,6 +109,11 @@ public class LocalMapStatsImplTest {
         assertEquals(7461762, localMapStats.getHeapCost());
         assertNotNull(localMapStats.getNearCacheStats());
         assertNotNull(localMapStats.toString());
+
+        assertEquals(10, localMapStats.getQueryCount());
+        assertEquals(5, localMapStats.getIndexedQueryCount());
+        assertNotNull(localMapStats.getIndexStats());
+        assertEquals(1, localMapStats.getIndexStats().size());
     }
 
     @Test
@@ -135,5 +150,10 @@ public class LocalMapStatsImplTest {
         assertEquals(7461762, deserialized.getHeapCost());
         assertNotNull(deserialized.getNearCacheStats());
         assertNotNull(deserialized.toString());
+
+        assertEquals(10, deserialized.getQueryCount());
+        assertEquals(5, deserialized.getIndexedQueryCount());
+        assertNotNull(deserialized.getIndexStats());
+        assertEquals(1, deserialized.getIndexStats().size());
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/query/impl/IndexImplTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/query/impl/IndexImplTest.java
@@ -18,6 +18,7 @@ package com.hazelcast.query.impl;
 
 import com.hazelcast.config.MapAttributeConfig;
 import com.hazelcast.internal.serialization.InternalSerializationService;
+import com.hazelcast.monitor.impl.InternalIndexStats;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.query.impl.getters.Extractors;
 import com.hazelcast.test.HazelcastParallelClassRunner;
@@ -47,7 +48,8 @@ public class IndexImplTest {
     public void setUp() {
         InternalSerializationService mockSerializationService = mock(InternalSerializationService.class);
         Extractors mockExtractors = new Extractors(Collections.<MapAttributeConfig>emptyList(), null);
-        index = new IndexImpl(ATTRIBUTE_NAME, false, mockSerializationService, mockExtractors, IndexCopyBehavior.COPY_ON_READ);
+        index = new IndexImpl(ATTRIBUTE_NAME, false, mockSerializationService, mockExtractors, IndexCopyBehavior.COPY_ON_READ,
+                InternalIndexStats.EMPTY);
     }
 
     @Test

--- a/hazelcast/src/test/java/com/hazelcast/query/impl/IndexTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/query/impl/IndexTest.java
@@ -20,11 +20,11 @@ import com.hazelcast.config.MapConfig;
 import com.hazelcast.core.PartitioningStrategy;
 import com.hazelcast.internal.serialization.InternalSerializationService;
 import com.hazelcast.internal.serialization.impl.DefaultSerializationServiceBuilder;
-import com.hazelcast.map.impl.query.DefaultIndexProvider;
 import com.hazelcast.map.impl.record.AbstractRecord;
 import com.hazelcast.map.impl.record.DataRecordFactory;
 import com.hazelcast.map.impl.record.Record;
 import com.hazelcast.map.impl.record.Records;
+import com.hazelcast.monitor.impl.InternalIndexStats;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.Data;
@@ -103,7 +103,7 @@ public class IndexTest {
 
     @Test
     public void testRemoveEnumIndex() {
-        Indexes is = new Indexes(ss, new DefaultIndexProvider(), Extractors.empty(), true, copyBehavior);
+        Indexes is = Indexes.createStandaloneIndexes(ss, copyBehavior);
         is.addOrGetIndex("favoriteCity", false);
         Data key = ss.toData(1);
         Data value = ss.toData(new SerializableWithEnum(SerializableWithEnum.City.ISTANBUL));
@@ -117,7 +117,7 @@ public class IndexTest {
 
     @Test
     public void testUpdateEnumIndex() {
-        Indexes is = new Indexes(ss, new DefaultIndexProvider(), Extractors.empty(), true, copyBehavior);
+        Indexes is = Indexes.createStandaloneIndexes(ss, copyBehavior);
         is.addOrGetIndex("favoriteCity", false);
         Data key = ss.toData(1);
         Data value = ss.toData(new SerializableWithEnum(SerializableWithEnum.City.ISTANBUL));
@@ -132,7 +132,7 @@ public class IndexTest {
 
     @Test
     public void testIndex() throws QueryException {
-        Indexes is = new Indexes(ss, new DefaultIndexProvider(), Extractors.empty(), true, copyBehavior);
+        Indexes is = Indexes.createStandaloneIndexes(ss, copyBehavior);
         Index dIndex = is.addOrGetIndex("d", false);
         Index boolIndex = is.addOrGetIndex("bool", false);
         Index strIndex = is.addOrGetIndex("str", false);
@@ -194,7 +194,7 @@ public class IndexTest {
 
     @Test
     public void testIndexWithNull() throws QueryException {
-        Indexes is = new Indexes(ss, new DefaultIndexProvider(), Extractors.empty(), true, copyBehavior);
+        Indexes is = Indexes.createStandaloneIndexes(ss, copyBehavior);
         Index strIndex = is.addOrGetIndex("str", true);
 
         Data value = ss.toData(new MainPortable(false, 1, null));
@@ -469,8 +469,8 @@ public class IndexTest {
     }
 
     private void testIt(boolean ordered) {
-        IndexImpl index
-                = new IndexImpl(QueryConstants.THIS_ATTRIBUTE_NAME.value(), ordered, ss, Extractors.empty(), copyBehavior);
+        IndexImpl index = new IndexImpl(QueryConstants.THIS_ATTRIBUTE_NAME.value(), ordered, ss, Extractors.empty(),
+                copyBehavior, InternalIndexStats.EMPTY);
         assertEquals(0, index.getRecords(0L).size());
         assertEquals(0, index.getSubRecordsBetween(0L, 1000L).size());
         QueryRecord record5 = newRecord(5L, 55L);

--- a/hazelcast/src/test/java/com/hazelcast/query/impl/IndexesTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/query/impl/IndexesTest.java
@@ -18,7 +18,6 @@ package com.hazelcast.query.impl;
 
 import com.hazelcast.internal.serialization.InternalSerializationService;
 import com.hazelcast.internal.serialization.impl.DefaultSerializationServiceBuilder;
-import com.hazelcast.map.impl.query.DefaultIndexProvider;
 import com.hazelcast.query.EntryObject;
 import com.hazelcast.query.PredicateBuilder;
 import com.hazelcast.query.SampleTestObjects.Employee;
@@ -65,7 +64,7 @@ public class IndexesTest {
 
     @Test
     public void testAndWithSingleEntry() {
-        Indexes indexes = new Indexes(serializationService, new DefaultIndexProvider(), Extractors.empty(), true, copyBehavior);
+        Indexes indexes = Indexes.createStandaloneIndexes(serializationService, copyBehavior);
         indexes.addOrGetIndex("name", false);
         indexes.addOrGetIndex("age", true);
         indexes.addOrGetIndex("salary", true);
@@ -87,7 +86,7 @@ public class IndexesTest {
 
     @Test
     public void testIndex() {
-        Indexes indexes = new Indexes(serializationService, new DefaultIndexProvider(), Extractors.empty(), true, copyBehavior);
+        Indexes indexes = Indexes.createStandaloneIndexes(serializationService, copyBehavior);
         indexes.addOrGetIndex("name", false);
         indexes.addOrGetIndex("age", true);
         indexes.addOrGetIndex("salary", true);
@@ -105,7 +104,7 @@ public class IndexesTest {
 
     @Test
     public void testIndex2() {
-        Indexes indexes = new Indexes(serializationService, new DefaultIndexProvider(), Extractors.empty(), true, copyBehavior);
+        Indexes indexes = Indexes.createStandaloneIndexes(serializationService, copyBehavior);
         indexes.addOrGetIndex("name", false);
         indexes.saveEntryIndex(new QueryEntry(serializationService, toData(1), new Value("abc"), Extractors.empty()), null);
         indexes.saveEntryIndex(new QueryEntry(serializationService, toData(2), new Value("xyz"), Extractors.empty()), null);
@@ -126,7 +125,7 @@ public class IndexesTest {
      */
     @Test
     public void shouldNotThrowException_withNullValues_whenIndexAddedForValueField() {
-        Indexes indexes = new Indexes(serializationService, new DefaultIndexProvider(), Extractors.empty(), true, copyBehavior);
+        Indexes indexes = Indexes.createStandaloneIndexes(serializationService, copyBehavior);
         indexes.addOrGetIndex("name", false);
 
         shouldReturnNull_whenQueryingOnKeys(indexes);
@@ -134,7 +133,7 @@ public class IndexesTest {
 
     @Test
     public void shouldNotThrowException_withNullValues_whenNoIndexAdded() {
-        Indexes indexes = new Indexes(serializationService, new DefaultIndexProvider(), Extractors.empty(), true, copyBehavior);
+        Indexes indexes = Indexes.createStandaloneIndexes(serializationService, copyBehavior);
 
         shouldReturnNull_whenQueryingOnKeys(indexes);
     }
@@ -152,7 +151,7 @@ public class IndexesTest {
 
     @Test
     public void shouldNotThrowException_withNullValue_whenIndexAddedForKeyField() {
-        Indexes indexes = new Indexes(serializationService, new DefaultIndexProvider(), Extractors.empty(), true, copyBehavior);
+        Indexes indexes = Indexes.createStandaloneIndexes(serializationService, copyBehavior);
         indexes.addOrGetIndex("__key", false);
 
         for (int i = 0; i < 100; i++) {

--- a/hazelcast/src/test/java/com/hazelcast/query/impl/predicates/BetweenVisitorTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/query/impl/predicates/BetweenVisitorTest.java
@@ -19,8 +19,8 @@ package com.hazelcast.query.impl.predicates;
 import com.hazelcast.core.TypeConverter;
 import com.hazelcast.query.Predicate;
 import com.hazelcast.query.impl.FalsePredicate;
-import com.hazelcast.query.impl.Index;
 import com.hazelcast.query.impl.Indexes;
+import com.hazelcast.query.impl.InternalIndex;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.annotation.ParallelTest;
 import com.hazelcast.test.annotation.QuickTest;
@@ -50,12 +50,12 @@ public class BetweenVisitorTest {
 
     private BetweenVisitor visitor;
     private Indexes mockIndexes;
-    private Index mockIndex;
+    private InternalIndex mockIndex;
 
     @Before
     public void setUp() {
         mockIndexes = mock(Indexes.class);
-        mockIndex = mock(Index.class);
+        mockIndex = mock(InternalIndex.class);
         when(mockIndexes.getIndex(anyString())).thenReturn(mockIndex);
         visitor = new BetweenVisitor();
         useConverter(INTEGER_CONVERTER);

--- a/hazelcast/src/test/java/com/hazelcast/query/impl/predicates/FlatteningVisitorTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/query/impl/predicates/FlatteningVisitorTest.java
@@ -18,8 +18,8 @@ package com.hazelcast.query.impl.predicates;
 
 import com.hazelcast.core.TypeConverter;
 import com.hazelcast.query.Predicate;
-import com.hazelcast.query.impl.Index;
 import com.hazelcast.query.impl.Indexes;
+import com.hazelcast.query.impl.InternalIndex;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.annotation.ParallelTest;
 import com.hazelcast.test.annotation.QuickTest;
@@ -45,12 +45,12 @@ public class FlatteningVisitorTest {
 
     private FlatteningVisitor visitor;
     private Indexes mockIndexes;
-    private Index mockIndex;
+    private InternalIndex mockIndex;
 
     @Before
     public void setUp() {
         mockIndexes = mock(Indexes.class);
-        mockIndex = mock(Index.class);
+        mockIndex = mock(InternalIndex.class);
         when(mockIndexes.getIndex(anyString())).thenReturn(mockIndex);
         visitor = new FlatteningVisitor();
         useConverter(INTEGER_CONVERTER);

--- a/hazelcast/src/test/java/com/hazelcast/query/impl/predicates/OrToInVisitorTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/query/impl/predicates/OrToInVisitorTest.java
@@ -18,8 +18,8 @@ package com.hazelcast.query.impl.predicates;
 
 import com.hazelcast.core.TypeConverter;
 import com.hazelcast.query.Predicate;
-import com.hazelcast.query.impl.Index;
 import com.hazelcast.query.impl.Indexes;
+import com.hazelcast.query.impl.InternalIndex;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.annotation.ParallelTest;
 import com.hazelcast.test.annotation.QuickTest;
@@ -47,12 +47,12 @@ public class OrToInVisitorTest {
 
     private OrToInVisitor visitor;
     private Indexes mockIndexes;
-    private Index mockIndex;
+    private InternalIndex mockIndex;
 
     @Before
     public void setUp() {
         mockIndexes = mock(Indexes.class);
-        mockIndex = mock(Index.class);
+        mockIndex = mock(InternalIndex.class);
         when(mockIndexes.getIndex(anyString())).thenReturn(mockIndex);
         visitor = new OrToInVisitor();
         useConverter(INTEGER_CONVERTER);

--- a/hazelcast/src/test/java/com/hazelcast/query/impl/predicates/PredicatesTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/query/impl/predicates/PredicatesTest.java
@@ -20,6 +20,7 @@ import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.IMap;
 import com.hazelcast.internal.serialization.InternalSerializationService;
 import com.hazelcast.internal.serialization.impl.DefaultSerializationServiceBuilder;
+import com.hazelcast.monitor.impl.InternalIndexStats;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.query.EntryObject;
 import com.hazelcast.query.IndexAwarePredicate;
@@ -312,7 +313,7 @@ public class PredicatesTest extends HazelcastTestSupport {
 
     @Test
     public void testNotEqualsPredicateDoesNotUseIndex() {
-        Index dummyIndex = new IndexImpl("foo", false, ss, Extractors.empty(), COPY_ON_READ);
+        Index dummyIndex = new IndexImpl("foo", false, ss, Extractors.empty(), COPY_ON_READ, InternalIndexStats.EMPTY);
         QueryContext mockQueryContext = mock(QueryContext.class);
         when(mockQueryContext.getIndex(anyString())).thenReturn(dummyIndex);
 


### PR DESCRIPTION
- `testAverageQuerySelectivityCalculation_ChangingNumberOfIndex()` - tests whether AverageQuerySelectivity work correctly even if number of entries (and index) in Map is changed

- `testAverageQueryLatencyTracking()` - I added some queries which do not use index and check that getAverageHitLatency() is not affected by them

- `testInsertsTracking()`, `testUpdateTracking()`, `testRemoveTracking()` - instead of checking that `getTotalRemoveLatency()` is higher than `0` I change it to check whether it is higher than previous `getTotalRemoveLatency()`

- `testInsertUpdateRemoveAreNotEffectEachOther()` - tests that insert, update and remove do not affect to each other (and also their total latency do not affect to each other)

- I also increased delta for `assertEquals` for double in AverageQuerySelectivity tests from 0.01 to 0.015 - according to https://github.com/hazelcast/hazelcast/pull/13359/files#diff-d8668fbc84476f5b762fe35938412124R47 it is around 1% so I increased it to 1.5% (I hit failing `ClientIndexStatsTest` because difference was 1.06%).